### PR TITLE
Stream hash computation in InMemoryBlockStore

### DIFF
--- a/modules/core/src/main/scala/graviton/impl/InMemoryBlockStore.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryBlockStore.scala
@@ -3,6 +3,7 @@ package graviton.impl
 import graviton.*
 import zio.*
 import zio.stream.*
+import zio.ChunkBuilder
 import io.github.iltotore.iron.*
 import io.github.iltotore.iron.constraint.all.*
 
@@ -12,18 +13,30 @@ final class InMemoryBlockStore private (
 ) extends BlockStore:
 
   def put: ZSink[Any, Throwable, Byte, Nothing, BlockKey] =
-    ZSink.collectAll[Byte].mapZIO { data =>
-      val chunk = Chunk.fromIterable(data)
-      for
-        hashBytes <- Hashing
-          .compute(Bytes(ZStream.fromChunk(chunk)), HashAlgorithm.SHA256)
-        digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
-        sizeRef = chunk.length.assume[Positive]
-        key = BlockKey(Hash(digest, HashAlgorithm.SHA256), sizeRef)
-        _ <- index.update(_ + key)
-        _ <- primary.write(key, Bytes(ZStream.fromChunk(chunk)))
-      yield key
-    }
+    val collect =
+      ZSink
+        .foldLeftChunks[Byte, ChunkBuilder[Byte]](ChunkBuilder.make[Byte]()) {
+          (b, ch) =>
+            b ++= ch
+        }
+        .map(_.result())
+    collect
+      .zipWithPar(Hashing.sink(HashAlgorithm.SHA256))((chunk, dig) => (chunk, dig))
+      .mapZIO { (chunk, hashBytes) =>
+        val digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
+        val sizeRef = chunk.length.assume[Positive]
+        val key = BlockKey(Hash(digest, HashAlgorithm.SHA256), sizeRef)
+        for
+          exists <- index.modify { s =>
+            val exists = s.contains(key)
+            val updated = if exists then s else s + key
+            (exists, updated)
+          }
+          _ <-
+            if exists then ZIO.unit
+            else primary.write(key, Bytes(ZStream.fromChunk(chunk)))
+        yield key
+      }
 
   def get(key: BlockKey): IO[Throwable, Option[Bytes]] =
     primary.read(key)


### PR DESCRIPTION
## Summary
- Avoid buffering entire blocks when hashing by streaming bytes through `Hashing.sink`
- Skip writing blocks that already exist and only update index for new blocks

## Testing
- `./sbt core/test`


------
https://chatgpt.com/codex/tasks/task_b_68b82736c3e0832eb46d710dea206cb6