### PR TITLE
Replicate operations across stacked binary stores

### DIFF
--- a/modules/core/src/main/scala/graviton/stacked/StackedBinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/stacked/StackedBinaryStore.scala
@@ -1,6 +1,7 @@
 package graviton.stacked
 
 import graviton.*
+import graviton.GravitonError.BackendUnavailable
 import zio.*
 import zio.stream.*
 
@@ -8,20 +9,70 @@ final case class StackedBinaryStore(
     primary: BinaryStore,
     replicas: Chunk[BinaryStore]
 ) extends BinaryStore:
+  private val allStores: Chunk[BinaryStore] = primary +: replicas
+
   def put(
       attrs: BinaryAttributes,
       chunkSize: Int
   ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
-    primary.put(attrs, chunkSize)
+    ZSink.collectAll[Byte].mapZIO { data =>
+      ZIO
+        .foldLeft(allStores)(List.empty[BinaryId]) { (acc, store) =>
+          Bytes(ZStream.fromChunk(data))
+            .run(store.put(attrs, chunkSize))
+            .either
+            .flatMap {
+              case Right(id)                   => ZIO.succeed(id :: acc)
+              case Left(_: BackendUnavailable) => ZIO.succeed(acc)
+              case Left(e)                     => ZIO.fail(e)
+            }
+        }
+        .flatMap {
+          case head :: _ => ZIO.succeed(head)
+          case Nil =>
+            ZIO.fail(BackendUnavailable("all replicas failed"))
+        }
+    }
 
   def get(
       id: BinaryId,
       range: Option[ByteRange] = None
   ): IO[Throwable, Option[Bytes]] =
-    primary.get(id, range)
+    def loop(
+        stores: Chunk[BinaryStore],
+        lastErr: Option[Throwable]
+    ): IO[Throwable, Option[Bytes]] =
+      stores.headOption match
+        case None =>
+          lastErr match
+            case Some(err) => ZIO.fail(err)
+            case None      => ZIO.succeed(None)
+        case Some(store) =>
+          store
+            .get(id, range)
+            .catchAll {
+              case e: BackendUnavailable => loop(stores.drop(1), Some(e))
+              case e                     => ZIO.fail(e)
+            }
+            .flatMap {
+              case Some(bytes) => ZIO.succeed(Some(bytes))
+              case None        => loop(stores.drop(1), lastErr)
+            }
+    loop(allStores, None)
 
   def delete(id: BinaryId): IO[Throwable, Boolean] =
-    primary.delete(id)
+    ZIO
+      .foreach(allStores) { store =>
+        store.delete(id).map(Right(_)).catchAll {
+          case e: BackendUnavailable => ZIO.succeed(Left(e))
+          case e                     => ZIO.fail(e)
+        }
+      }
+      .flatMap { results =>
+        val successes = results.collect { case Right(b) => b }
+        if successes.nonEmpty then ZIO.succeed(successes.exists(identity))
+        else ZIO.fail(BackendUnavailable("all replicas failed"))
+      }
 
   def exists(id: BinaryId): IO[Throwable, Boolean] =
     primary.exists(id)


### PR DESCRIPTION
## Summary
- Replicate binary writes across primary and replica stores, failing only if all replicas are unavailable
- Read from replicas on primary miss or backend failures
- Propagate deletions to every store with aggregated error handling

## Testing
- `./sbt scalafmtCheckAll`
- `./sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68b82ba99930832ead0fabeb7eac463e