### PR TITLE
Track block sectors via resolver

### DIFF
--- a/docs/src/main/mdoc/architecture.md
+++ b/docs/src/main/mdoc/architecture.md
@@ -4,12 +4,14 @@ Graviton organizes immutable binary data into a layered model inspired by the
 Binny `BinaryStore`:
 
 1. **Block** – a deduplicated chunk of bytes identified by a cryptographic
-   `BlockKey`. Blocks are immutable and can be stored in multiple locations.
+   `BlockKey`. Blocks are immutable and can be stored in multiple locations,
+   with each physical copy represented as a `BlockSector`.
 2. **BlobStore** – a pluggable backend that persists blocks on a filesystem,
    object store, or other medium. Each store reports its health and lifecycle
    status.
 3. **BlockStore** – a logical registry that hashes incoming streams, writes the
-   resulting blocks to one or more `BlobStore`s, and looks them up by key.
+   resulting blocks to one or more `BlobStore`s, and records sectors through a
+   `BlockResolver` which is consulted on reads.
 4. **File** – an ordered sequence of block keys. A file's identity (`FileKey`)
    is derived from the canonical content hash and is independent of chunking.
 5. **FileStore** – assembles files from blocks, records manifests, and provides

--- a/docs/src/main/mdoc/binary-store.md
+++ b/docs/src/main/mdoc/binary-store.md
@@ -32,8 +32,10 @@ and MinIO implementations live in dedicated modules.
 
 ### BlockStore
 A logical registry that hashes incoming streams, deduplicates blocks, and
-forwards them to `BlobStore`s.  It exposes sinks for streaming writes and
-streams for listings.
+forwards them to `BlobStore`s.  Each write records a `BlockSector` so that the
+`BlockResolver` can track every physical copy.  Reads consult the resolver and
+fan‑out across sectors, allowing blocks to exist in multiple locations.  The
+store exposes sinks for streaming writes and streams for listings.
 
 ### File
 A file is an ordered list of `BlockKey`s.  Its identity, the `FileKey`, is based

--- a/modules/core/src/main/scala/graviton/BlockResolver.scala
+++ b/modules/core/src/main/scala/graviton/BlockResolver.scala
@@ -1,0 +1,7 @@
+package graviton
+
+import zio.*
+
+trait BlockResolver:
+  def record(key: BlockKey, sector: BlockSector): UIO[Unit]
+  def resolve(key: BlockKey): UIO[Chunk[BlockSector]]

--- a/modules/core/src/main/scala/graviton/BlockSector.scala
+++ b/modules/core/src/main/scala/graviton/BlockSector.scala
@@ -1,0 +1,6 @@
+package graviton
+
+final case class BlockSector(
+    blobStoreId: BlobStoreId,
+    status: BlobStoreStatus
+)

--- a/modules/core/src/main/scala/graviton/impl/InMemoryBlockResolver.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryBlockResolver.scala
@@ -1,0 +1,22 @@
+package graviton.impl
+
+import graviton.*
+import zio.*
+
+final class InMemoryBlockResolver private (
+    state: Ref[Map[BlockKey, Set[BlockSector]]]
+) extends BlockResolver:
+  def record(key: BlockKey, sector: BlockSector): UIO[Unit] =
+    state.update { m =>
+      val existing = m.getOrElse(key, Set.empty)
+      m.updated(key, existing + sector)
+    }
+
+  def resolve(key: BlockKey): UIO[Chunk[BlockSector]] =
+    state.get.map { m =>
+      Chunk.fromIterable(m.getOrElse(key, Set.empty))
+    }
+
+object InMemoryBlockResolver:
+  def make: UIO[InMemoryBlockResolver] =
+    Ref.make(Map.empty[BlockKey, Set[BlockSector]]).map(new InMemoryBlockResolver(_))

--- a/modules/core/src/main/scala/graviton/impl/InMemoryBlockResolver.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryBlockResolver.scala
@@ -19,4 +19,6 @@ final class InMemoryBlockResolver private (
 
 object InMemoryBlockResolver:
   def make: UIO[InMemoryBlockResolver] =
-    Ref.make(Map.empty[BlockKey, Set[BlockSector]]).map(new InMemoryBlockResolver(_))
+    Ref
+      .make(Map.empty[BlockKey, Set[BlockSector]])
+      .map(new InMemoryBlockResolver(_))

--- a/modules/core/src/main/scala/graviton/impl/InMemoryBlockStore.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryBlockStore.scala
@@ -39,12 +39,13 @@ final class InMemoryBlockStore private (
           _ <-
             if exists then ZIO.unit
             else
-              for
+              (for
                 _ <- primary.write(key, Bytes(ZStream.fromChunk(chunk)))
                 status <- primary.status
                 _ <- resolver.record(key, BlockSector(primary.id, status))
               yield ()
-      yield key
+            )
+        yield key
       }
 
   def get(key: BlockKey): IO[Throwable, Option[Bytes]] =

--- a/modules/core/src/test/scala/graviton/FileStoreSpec.scala
+++ b/modules/core/src/test/scala/graviton/FileStoreSpec.scala
@@ -13,7 +13,8 @@ object FileStoreSpec extends ZIOSpecDefault:
         def detect(bytes: Bytes) = ZIO.succeed(Some("text/plain"))
       for
         blob <- InMemoryBlobStore.make()
-        blocks <- InMemoryBlockStore.make(blob)
+        resolver <- InMemoryBlockResolver.make
+        blocks <- InMemoryBlockStore.make(blob, resolver)
         files <- InMemoryFileStore.make(blocks, detect)
         fk <- ZStream
           .fromIterable("abc" * 1000)
@@ -30,7 +31,8 @@ object FileStoreSpec extends ZIOSpecDefault:
         def detect(bytes: Bytes) = ZIO.succeed(Some("text/plain"))
       val attempt = for
         blob <- InMemoryBlobStore.make()
-        blocks <- InMemoryBlockStore.make(blob)
+        resolver <- InMemoryBlockResolver.make
+        blocks <- InMemoryBlockStore.make(blob, resolver)
         files <- InMemoryFileStore.make(blocks, detect)
         _ <- ZStream
           .fromIterable("data".getBytes.toIndexedSeq)


### PR DESCRIPTION
## Summary
- model block storage locations with `BlockSector`
- resolve block sectors through new `BlockResolver`
- block store records sectors on write and consults resolver on read
- document multi-location blocks and add cross-store test coverage

## Testing
- `./sbt -batch test`

------
https://chatgpt.com/codex/tasks/task_b_68b82d75d4e8832eb4ff010c522f6812