### PR TITLE
Consolidate attribute representation

### DIFF
--- a/docs/src/main/mdoc/binary-store.md
+++ b/docs/src/main/mdoc/binary-store.md
@@ -70,3 +70,10 @@ modules/tika    – media type detection utilities
 
 Each module provides a `ZLayer` for easy wiring into ZIO applications.
 
+## Migration Notes
+
+The attribute system has been consolidated around `graviton.core.BinaryAttributes`.
+The previous `AttributeName`/`BinaryAttributes` pair has been removed in favour of
+typed `BinaryAttributeKey`s, so downstream code should construct and query
+attributes using the new API.
+

--- a/modules/core/src/main/scala/graviton/AttributeName.scala
+++ b/modules/core/src/main/scala/graviton/AttributeName.scala
@@ -1,6 +1,0 @@
-package graviton
-
-opaque type AttributeName = String
-
-object AttributeName:
-  inline def apply(name: String): AttributeName = name

--- a/modules/core/src/main/scala/graviton/BinaryAttributes.scala
+++ b/modules/core/src/main/scala/graviton/BinaryAttributes.scala
@@ -1,3 +1,0 @@
-package graviton
-
-final case class BinaryAttributes(values: Map[AttributeName, String])

--- a/modules/core/src/main/scala/graviton/BinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/BinaryStore.scala
@@ -1,5 +1,6 @@
 package graviton
 
+import graviton.core.BinaryAttributes
 import zio.*
 import zio.stream.*
 

--- a/modules/core/src/main/scala/graviton/ChunkedBinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/ChunkedBinaryStore.scala
@@ -1,5 +1,6 @@
 package graviton
 
+import graviton.core.BinaryAttributes
 import zio.*
 import zio.stream.*
 

--- a/modules/core/src/main/scala/graviton/impl/DefaultCopyTool.scala
+++ b/modules/core/src/main/scala/graviton/impl/DefaultCopyTool.scala
@@ -1,6 +1,7 @@
 package graviton.impl
 
 import graviton.*
+import graviton.core.BinaryAttributes
 import zio.*
 
 /** Default implementation of [[CopyTool]].
@@ -23,7 +24,7 @@ final class DefaultCopyTool extends CopyTool:
         .get(id)
         .someOrFail(GravitonError.NotFound(s"binary $id not found"))
       _ <-
-        bytes.run(dest.put(BinaryAttributes(Map.empty), DefaultChunkSize)).unit
+        bytes.run(dest.put(BinaryAttributes.empty, DefaultChunkSize)).unit
     yield ()
 
     for

--- a/modules/core/src/main/scala/graviton/stacked/StackedBinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/stacked/StackedBinaryStore.scala
@@ -2,6 +2,7 @@ package graviton.stacked
 
 import graviton.*
 import graviton.GravitonError.BackendUnavailable
+import graviton.core.BinaryAttributes
 import zio.*
 import zio.stream.*
 


### PR DESCRIPTION
## Summary
- replace legacy `AttributeName`/`BinaryAttributes` with typed `graviton.core.BinaryAttributes`
- update BinaryStore utilities to use the new attribute model
- document migration to the unified attribute system

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68b8307ced20832eadb6b49dc2326e30