### PR TITLE
Add range support for blob reads

### DIFF
--- a/modules/core/src/main/scala/graviton/BlobStore.scala
+++ b/modules/core/src/main/scala/graviton/BlobStore.scala
@@ -6,6 +6,9 @@ import zio.stream.*
 trait BlobStore:
   def id: BlobStoreId
   def status: UIO[BlobStoreStatus]
-  def read(key: BlockKey): IO[Throwable, Option[Bytes]]
+  def read(
+      key: BlockKey,
+      range: Option[ByteRange] = None
+  ): IO[Throwable, Option[Bytes]]
   def write(key: BlockKey, data: Bytes): IO[Throwable, Unit]
   def delete(key: BlockKey): IO[Throwable, Boolean]

--- a/modules/core/src/main/scala/graviton/BlockStore.scala
+++ b/modules/core/src/main/scala/graviton/BlockStore.scala
@@ -5,7 +5,10 @@ import zio.stream.*
 
 trait BlockStore:
   def put: ZSink[Any, Throwable, Byte, Nothing, BlockKey]
-  def get(key: BlockKey): IO[Throwable, Option[Bytes]]
+  def get(
+      key: BlockKey,
+      range: Option[ByteRange] = None
+  ): IO[Throwable, Option[Bytes]]
   def has(key: BlockKey): IO[Throwable, Boolean]
   def delete(key: BlockKey): IO[Throwable, Boolean]
   def list(selector: BlockKeySelector): ZStream[Any, Throwable, BlockKey]

--- a/modules/core/src/main/scala/graviton/impl/InMemoryBlockStore.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryBlockStore.scala
@@ -48,7 +48,10 @@ final class InMemoryBlockStore private (
         yield key
       }
 
-  def get(key: BlockKey): IO[Throwable, Option[Bytes]] =
+  def get(
+      key: BlockKey,
+      range: Option[ByteRange] = None
+  ): IO[Throwable, Option[Bytes]] =
     resolver.resolve(key).flatMap { sectors =>
       def loop(rem: Chunk[BlockSector]): IO[Throwable, Option[Bytes]] =
         rem.headOption match
@@ -57,7 +60,7 @@ final class InMemoryBlockStore private (
             stores.get(sec.blobStoreId) match
               case None => loop(rem.drop(1))
               case Some(store) =>
-                store.read(key).flatMap {
+                store.read(key, range).flatMap {
                   case None => loop(rem.drop(1))
                   case s    => ZIO.succeed(s)
                 }

--- a/modules/fs/src/main/scala/graviton/fs/FileSystemBlobStore.scala
+++ b/modules/fs/src/main/scala/graviton/fs/FileSystemBlobStore.scala
@@ -15,10 +15,35 @@ final class FileSystemBlobStore private (root: Path, val id: BlobStoreId)
 
   def status: UIO[BlobStoreStatus] = ZIO.succeed(BlobStoreStatus.Operational)
 
-  def read(key: BlockKey): IO[Throwable, Option[Bytes]] =
+  def read(
+      key: BlockKey,
+      range: Option[ByteRange] = None
+  ): IO[Throwable, Option[Bytes]] =
     ZIO.attempt(Files.exists(pathFor(key))).flatMap { exists =>
       if !exists then ZIO.succeed(None)
-      else ZIO.succeed(Some(Bytes(ZStream.fromPath(pathFor(key)))))
+      else
+        val p = pathFor(key)
+        ZIO.scoped {
+          ZIO
+            .fromAutoCloseable(ZIO.attempt(Files.newByteChannel(p)))
+            .flatMap { ch =>
+              val size = ch.size()
+              val (start, end) =
+                range.map(r => (r.start, r.endExclusive)).getOrElse((0L, size))
+              val len = (end - start).toInt
+              val buf = java.nio.ByteBuffer.allocate(len)
+              ZIO.attempt {
+                ch.position(start)
+                var read = 0
+                while read < len do
+                  val n = ch.read(buf)
+                  if n < 0 then throw new java.io.EOFException()
+                  read += n
+                buf.flip()
+                Some(Bytes(ZStream.fromChunk(zio.Chunk.fromByteBuffer(buf))))
+              }
+            }
+        }
     }
 
   def write(key: BlockKey, data: Bytes): IO[Throwable, Unit] =


### PR DESCRIPTION
## Summary
- allow blob and block stores to read by byte range
- implement range reads in filesystem and MinIO blob stores
- cover partial block and file reads with new tests

## Testing
- `./sbt core/test`
- `./sbt fs/test`


------
https://chatgpt.com/codex/tasks/task_b_68b8309004e0832e816cf9270e85c25d