### PR TITLE
docs: flesh out README and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,5 @@ jobs:
         run: ./sbt scalafmtCheckAll
       - name: Test
         run: ./sbt test
+      - name: Docs build
+        run: ./sbt docs/mdoc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,59 @@
 # Graviton
 
-ZIO‑native content‑addressable storage inspired by Binny. Documentation is
-available under the [docs](docs/src/main/mdoc/index.md) directory and published as part of
-the project site.
+ZIO‑native content‑addressable storage inspired by Binny.
+
+## Features
+
+* Content‑addressable binary store with BLAKE3 hashing
+* Pluggable blob stores (filesystem, MinIO/S3, …)
+* ZIO Streams based APIs for non‑blocking I/O
+* Media type detection utilities backed by Apache Tika
+
+## Architecture
+
+```mermaid
+graph TD
+    B[Block] -->|persists| S[BlobStore]
+    B --> R[BlockStore]
+    R --> F[File]
+    F --> M[FileStore]
+    M --> V[View]
+```
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant BS as BlockStore
+    participant BL as BlobStore
+    participant RS as Resolver
+
+    C->>BS: stream file bytes
+    BS->>BL: write blocks
+    BS->>RS: register sectors
+    BS-->>C: FileKey
+```
+
+## Quickstart
+
+### CLI
+
+```bash
+# ingest a file
+graviton put README.md
+# retrieve the file using the returned key
+graviton get <fileKey> > README.copy.md
+```
+
+### HTTP Gateway
+
+Assuming the gateway is running on `localhost:8080`:
+
+```bash
+# upload bytes
+curl -X POST --data-binary @README.md http://localhost:8080/files
+# download the stored file
+curl http://localhost:8080/files/<fileKey> -o README.copy.md
+```
+
+Documentation lives under the [docs](docs/src/main/mdoc/index.md) directory and
+is published as part of the project site.

--- a/docs/src/main/mdoc/examples/cli.md
+++ b/docs/src/main/mdoc/examples/cli.md
@@ -1,0 +1,12 @@
+# CLI Example
+
+The `graviton` CLI ingests and retrieves files via the local store.
+
+```bash
+# ingest a file and capture the returned FileKey
+$ graviton put README.md
+FILE_KEY=...
+
+# retrieve the stored bytes
+$ graviton get $FILE_KEY > README.copy.md
+```

--- a/docs/src/main/mdoc/examples/http.md
+++ b/docs/src/main/mdoc/examples/http.md
@@ -1,0 +1,12 @@
+# HTTP Gateway Example
+
+Assuming the gateway is running on `localhost:8080`:
+
+```bash
+# upload a file
+$ curl -X POST --data-binary @README.md http://localhost:8080/files
+{"fileKey":"..."}
+
+# download the stored file
+$ curl http://localhost:8080/files/<fileKey> -o README.copy.md
+```

--- a/docs/src/main/mdoc/examples/index.md
+++ b/docs/src/main/mdoc/examples/index.md
@@ -1,0 +1,7 @@
+# Examples
+
+* [CLI](cli.md)
+* [HTTP Gateway](http.md)
+
+These walkthroughs show how to ingest and fetch data using the command-line
+interface or the HTTP gateway.

--- a/docs/src/main/mdoc/index.md
+++ b/docs/src/main/mdoc/index.md
@@ -17,3 +17,6 @@ stack.
 
 Additional details about the layered model and terminology live in
 [binary-store.md](binary-store.md).
+
+See the [examples](examples/index.md) for end‑to‑end CLI and HTTP gateway
+walkthroughs.


### PR DESCRIPTION
## Summary
- document features, architecture diagrams, and quickstart in README
- add CLI and HTTP gateway walkthroughs under docs/examples and link from docs index
- build docs in CI to verify site generation

## Testing
- `./sbt scalafmtCheckAll`
- `./sbt test`
- `./sbt docs/mdoc`


------
https://chatgpt.com/codex/tasks/task_b_68b836d93894832eadd28973c12e7ac6