### PR TITLE
Add metrics module with Prometheus telemetry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val zioV        = "2.1.20"
 lazy val zioPreludeV = "1.0.0-RC41"
 lazy val ironV       = "3.2.0"
 lazy val zioSchemaV  = "1.7.4"
+lazy val zioMetricsV = "2.4.3"
 
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
@@ -23,7 +24,7 @@ lazy val commonSettings = Seq(
   testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
 )
 
-lazy val root = (project in file(".")).aggregate(core, fs, minio, tika, docs)
+lazy val root = (project in file(".")).aggregate(core, fs, minio, tika, metrics, docs)
   .settings(name := "graviton")
 
 lazy val core = project
@@ -47,6 +48,15 @@ lazy val minio = project
   .settings(
     name := "graviton-minio",
     libraryDependencies += "io.minio" % "minio" % "8.5.9"
+  )
+  .settings(commonSettings)
+
+lazy val metrics = project
+  .in(file("modules/metrics"))
+  .dependsOn(core)
+  .settings(
+    name := "graviton-metrics",
+    libraryDependencies += "dev.zio" %% "zio-metrics-connectors-prometheus" % zioMetricsV
   )
   .settings(commonSettings)
 

--- a/docs/src/main/mdoc/index.md
+++ b/docs/src/main/mdoc/index.md
@@ -10,6 +10,7 @@ Quasar and other applications.
 * **fs** – filesystem backed blob store.
 * **minio** – S3‑compatible blob store using zio‑aws.
 * **tika** – media type detection utilities backed by Apache Tika.
+* **metrics** – Prometheus instrumentation for core operations.
 * [Scan utilities](scan.md) – composable streaming transformers.
 
 See [architecture.md](architecture.md) for a high‑level overview of the storage

--- a/docs/src/main/mdoc/metrics.md
+++ b/docs/src/main/mdoc/metrics.md
@@ -1,0 +1,50 @@
+# Metrics
+
+The `graviton-metrics` module instruments core binary store operations and
+exposes Prometheus-compatible telemetry.
+
+## Enabling metrics
+
+Add the dependency and layer into your application:
+
+```scala
+libraryDependencies += "io.quasar" %% "graviton-metrics" % "<version>"
+```
+
+Wrap an existing `BinaryStore` with `MetricsBinaryStore` to collect counts and
+latencies for `put`, `get`, and `delete`:
+
+```scala
+import graviton.metrics.*
+
+val instrumented = MetricsBinaryStore(store)
+```
+
+Include the Prometheus publisher and updater layers to export metrics:
+
+```scala
+val layer = Metrics.prometheus ++ Metrics.prometheusUpdater
+```
+
+## Scraping
+
+Expose the scraped data through an HTTP endpoint:
+
+```scala
+Metrics.scrape
+```
+
+Configure Prometheus to scrape the endpoint:
+
+```yaml
+scrape_configs:
+  - job_name: "graviton"
+    static_configs:
+      - targets: ["localhost:8080"]
+```
+
+## Dashboards
+
+Once metrics are collected, import them into Grafana and create panels based on
+`graviton_put_total`, `graviton_get_latency_seconds`, and other metrics to
+monitor usage and performance.

--- a/modules/metrics/src/main/scala/graviton/metrics/Metrics.scala
+++ b/modules/metrics/src/main/scala/graviton/metrics/Metrics.scala
@@ -1,0 +1,38 @@
+package graviton.metrics
+
+import zio.*
+import zio.metrics.*
+import zio.metrics.connectors.prometheus.{
+  PrometheusPublisher,
+  prometheusLayer,
+  publisherLayer
+}
+import zio.metrics.connectors.MetricsConfig
+import java.time.Duration
+
+object Metrics:
+  val putCount: Metric.Counter[Int] = Metric.counterInt("graviton_put_total")
+  val putLatency = Metric.timer(
+    "graviton_put_latency_seconds",
+    java.time.temporal.ChronoUnit.SECONDS
+  )
+  val getCount: Metric.Counter[Int] = Metric.counterInt("graviton_get_total")
+  val getLatency = Metric.timer(
+    "graviton_get_latency_seconds",
+    java.time.temporal.ChronoUnit.SECONDS
+  )
+  val deleteCount: Metric.Counter[Int] =
+    Metric.counterInt("graviton_delete_total")
+  val deleteLatency = Metric.timer(
+    "graviton_delete_latency_seconds",
+    java.time.temporal.ChronoUnit.SECONDS
+  )
+
+  val prometheus: ULayer[PrometheusPublisher] = publisherLayer
+
+  val prometheusUpdater: ZLayer[PrometheusPublisher, Nothing, Unit] =
+    ZLayer.succeed(MetricsConfig(Duration.ofSeconds(5))) >>>
+      prometheusLayer
+
+  def scrape: ZIO[PrometheusPublisher, Nothing, String] =
+    ZIO.serviceWithZIO[PrometheusPublisher](_.get)

--- a/modules/metrics/src/main/scala/graviton/metrics/MetricsBinaryStore.scala
+++ b/modules/metrics/src/main/scala/graviton/metrics/MetricsBinaryStore.scala
@@ -1,0 +1,49 @@
+package graviton.metrics
+
+import graviton.{BinaryId, BinaryStore, ByteRange}
+import graviton.core.BinaryAttributes
+import zio.*
+import zio.stream.*
+import Metrics.*
+
+final case class MetricsBinaryStore(underlying: BinaryStore)
+    extends BinaryStore:
+  override def put(
+      attrs: BinaryAttributes,
+      chunkSize: Int
+  ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
+    ZSink.unwrapScoped {
+      Clock.nanoTime.map { start =>
+        underlying.put(attrs, chunkSize).mapZIO { id =>
+          for
+            end <- Clock.nanoTime
+            _ <- putCount.increment
+            _ <- putLatency.update(Duration.fromNanos(end - start))
+          yield id
+        }
+      }
+    }
+
+  override def get(
+      id: BinaryId,
+      range: Option[ByteRange]
+  ): IO[Throwable, Option[graviton.Bytes]] =
+    for
+      start <- Clock.nanoTime
+      res <- underlying.get(id, range)
+      end <- Clock.nanoTime
+      _ <- getCount.increment
+      _ <- getLatency.update(Duration.fromNanos(end - start))
+    yield res
+
+  override def delete(id: BinaryId): IO[Throwable, Boolean] =
+    for
+      start <- Clock.nanoTime
+      res <- underlying.delete(id)
+      end <- Clock.nanoTime
+      _ <- deleteCount.increment
+      _ <- deleteLatency.update(Duration.fromNanos(end - start))
+    yield res
+
+  override def exists(id: BinaryId): IO[Throwable, Boolean] =
+    underlying.exists(id)

--- a/modules/metrics/src/test/scala/graviton/metrics/MetricsBinaryStoreSpec.scala
+++ b/modules/metrics/src/test/scala/graviton/metrics/MetricsBinaryStoreSpec.scala
@@ -1,0 +1,43 @@
+package graviton.metrics
+
+import graviton.{BinaryId, BinaryStore, ByteRange}
+import graviton.core.BinaryAttributes
+import zio.*
+import zio.stream.*
+import zio.test.*
+
+object MetricsBinaryStoreSpec extends ZIOSpecDefault:
+  private val stub = new BinaryStore:
+    def put(
+        attrs: BinaryAttributes,
+        chunkSize: Int
+    ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
+      ZSink.succeed(BinaryId("id"))
+    def get(
+        id: BinaryId,
+        range: Option[ByteRange]
+    ): IO[Throwable, Option[graviton.Bytes]] =
+      ZIO.succeed(None)
+    def delete(id: BinaryId): IO[Throwable, Boolean] =
+      ZIO.succeed(true)
+    def exists(id: BinaryId): IO[Throwable, Boolean] =
+      ZIO.succeed(true)
+
+  def spec = suite("MetricsBinaryStore")(
+    test("records get count") {
+      val store = MetricsBinaryStore(stub)
+      for
+        before <- Metrics.getCount.value.map(_.count)
+        _ <- store.get(BinaryId("a"), None)
+        after <- Metrics.getCount.value.map(_.count)
+      yield assertTrue(after == before + 1)
+    },
+    test("records delete count") {
+      val store = MetricsBinaryStore(stub)
+      for
+        before <- Metrics.deleteCount.value.map(_.count)
+        _ <- store.delete(BinaryId("a"))
+        after <- Metrics.deleteCount.value.map(_.count)
+      yield assertTrue(after == before + 1)
+    }
+  )


### PR DESCRIPTION
## Summary
- add `graviton-metrics` module with Prometheus connectors
- instrument `BinaryStore` operations with counters and timers
- document enabling, scraping, and dashboarding metrics

## Testing
- `./sbt test`
- `./sbt docs/mdoc`


------
https://chatgpt.com/codex/tasks/task_b_68b836cfbe04832e94a4a112d754b7e4