### PR TITLE
Add local disk and RocksDB caching stores

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,15 @@ lazy val zioPreludeV = "1.0.0-RC41"
 lazy val ironV       = "3.2.0"
 lazy val zioSchemaV  = "1.7.4"
 lazy val zioMetricsV = "2.4.3"
+lazy val zioCacheV       = "0.2.4"
+lazy val zioRocksdbV     = "0.4.4"
+lazy val testContainersV = "1.19.7"
 
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "dev.zio" %% "zio"         % zioV,
     "dev.zio" %% "zio-streams" % zioV,
+    "dev.zio" %% "zio-cache"   % zioCacheV,
     "dev.zio" %% "zio-prelude" % zioPreludeV,
     "dev.zio" %% "zio-schema"        % zioSchemaV,
     "dev.zio" %% "zio-schema-derivation" % zioSchemaV,
@@ -38,7 +42,11 @@ lazy val fs = project
   .in(file("modules/fs"))
   .dependsOn(core)
   .settings(
-    name := "graviton-fs"
+    name := "graviton-fs",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio-rocksdb"   % zioRocksdbV,
+      "org.testcontainers" % "testcontainers" % testContainersV % Test
+    )
   )
   .settings(commonSettings)
 

--- a/modules/core/src/main/scala/graviton/CacheStore.scala
+++ b/modules/core/src/main/scala/graviton/CacheStore.scala
@@ -1,0 +1,28 @@
+package graviton
+
+import zio.*
+
+/** Simple abstraction for caching binary content by [[Hash]]. Implementations
+  * must verify that any cached data matches the requested hash before serving
+  * it and fall back to the provided download effect when the cache is absent or
+  * invalid.
+  */
+trait CacheStore:
+  /** Retrieve data for the supplied [[Hash]].
+    *
+    * @param hash
+    *   expected hash of the content
+    * @param download
+    *   effect producing the content when it is not cached or the cached value
+    *   is invalid
+    * @param useCache
+    *   when `false`, caching is bypassed and `download` is always executed
+    */
+  def fetch(
+      hash: Hash,
+      download: => Task[Bytes],
+      useCache: Boolean = true
+  ): Task[Bytes]
+
+  /** Remove any cached value associated with the supplied hash. */
+  def invalidate(hash: Hash): UIO[Unit]

--- a/modules/fs/src/main/scala/graviton/fs/DiskCacheStore.scala
+++ b/modules/fs/src/main/scala/graviton/fs/DiskCacheStore.scala
@@ -1,0 +1,100 @@
+package graviton.fs
+
+import graviton.*
+import zio.*
+import zio.cache.*
+import zio.stream.*
+import zio.Duration
+import java.nio.file.{Files, Path}
+
+/** Local-disk [[CacheStore]] backed by [[zio.cache.Cache]]. Cached entries are
+  * stored under `root/<hash-hex>` and validated against the expected hash
+  * before being served.
+  */
+final class DiskCacheStore private (
+    root: Path,
+    cache: Cache[Hash, Throwable, Chunk[Byte]],
+    loaderRef: FiberRef[Hash => Task[Chunk[Byte]]]
+) extends CacheStore:
+
+  private def fromChunk(ch: Chunk[Byte]): Bytes = Bytes(ZStream.fromChunk(ch))
+
+  def fetch(
+      hash: Hash,
+      download: => Task[Bytes],
+      useCache: Boolean
+  ): Task[Bytes] =
+    if !useCache then
+      for
+        data <- download
+        chunk <- data.runCollect
+        _ <- DiskCacheStore.verify(hash, chunk)
+      yield fromChunk(chunk)
+    else
+      loaderRef.locally((_: Hash) => download.flatMap(_.runCollect)) {
+        cache.get(hash).map(fromChunk)
+      }
+
+  def invalidate(hash: Hash): UIO[Unit] =
+    cache.invalidate(hash) *>
+      ZIO.attempt(Files.deleteIfExists(root.resolve(hash.hex))).ignore
+
+object DiskCacheStore:
+  private def verify(hash: Hash, data: Chunk[Byte]): Task[Unit] =
+    for
+      dig <- Hashing.compute(Bytes(ZStream.fromChunk(data)), hash.algo)
+      _ <- ZIO
+        .fail(RuntimeException("hash mismatch"))
+        .unless(dig == hash.bytes)
+    yield ()
+
+  private def loader(
+      root: Path,
+      ref: FiberRef[Hash => Task[Chunk[Byte]]]
+  )(hash: Hash): Task[Chunk[Byte]] =
+    val path = root.resolve(hash.hex)
+    def downloadAndWrite: Task[Chunk[Byte]] =
+      for
+        remote <- ref.get
+        chunk <- remote(hash)
+        _ <- verify(hash, chunk)
+        _ <- ZIO.attempt(Files.createDirectories(path.getParent))
+        _ <- ZIO.attempt(Files.write(path, chunk.toArray))
+      yield chunk
+    for
+      exists <- ZIO.attempt(Files.exists(path))
+      chunk <-
+        if exists then
+          for
+            arr <- ZIO.attempt(Files.readAllBytes(path)).map(Chunk.fromArray)
+            ok <- Hashing
+              .compute(Bytes(ZStream.fromChunk(arr)), hash.algo)
+              .map(_ == hash.bytes)
+            res <- if ok then ZIO.succeed(arr) else downloadAndWrite
+          yield res
+        else downloadAndWrite
+    yield chunk
+
+  /** Construct a [[DiskCacheStore]]. */
+  def make(
+      root: Path,
+      capacity: Int = 1024,
+      ttl: Duration = Duration.Infinity
+  ): ZIO[Scope, Nothing, DiskCacheStore] =
+    for
+      ref <- FiberRef.make[Hash => Task[Chunk[Byte]]]((_: Hash) =>
+        ZIO.fail(RuntimeException("no loader"))
+      )
+      cache <- Cache.make[Hash, Any, Throwable, Chunk[Byte]](
+        capacity,
+        ttl,
+        Lookup(loader(root, ref))
+      )
+    yield DiskCacheStore(root, cache, ref)
+
+  def layer(
+      root: Path,
+      capacity: Int = 1024,
+      ttl: Duration = Duration.Infinity
+  ): ZLayer[Any, Nothing, CacheStore] =
+    ZLayer.scoped(make(root, capacity, ttl))

--- a/modules/fs/src/main/scala/graviton/fs/RocksDBCacheStore.scala
+++ b/modules/fs/src/main/scala/graviton/fs/RocksDBCacheStore.scala
@@ -1,0 +1,105 @@
+package graviton.fs
+
+import graviton.*
+import zio.*
+import zio.cache.*
+import zio.stream.*
+import zio.Duration
+import java.nio.file.Path
+import zio.rocksdb.{RocksDB as ZRocksDB}
+
+/** [[CacheStore]] backed by RocksDB for persistent storage. Cached entries are
+  * keyed by the hex representation of the [[Hash]] and validated against the
+  * expected digest before use.
+  */
+final class RocksDBCacheStore private (
+    db: ZRocksDB,
+    cache: Cache[Hash, Throwable, Chunk[Byte]],
+    loaderRef: FiberRef[Hash => Task[Chunk[Byte]]]
+) extends CacheStore:
+
+  private def fromChunk(ch: Chunk[Byte]): Bytes = Bytes(ZStream.fromChunk(ch))
+
+  def fetch(
+      hash: Hash,
+      download: => Task[Bytes],
+      useCache: Boolean
+  ): Task[Bytes] =
+    if !useCache then
+      for
+        data <- download
+        chunk <- data.runCollect
+        _ <- RocksDBCacheStore.verify(hash, chunk)
+      yield fromChunk(chunk)
+    else
+      loaderRef.locally((_: Hash) => download.flatMap(_.runCollect)) {
+        cache.get(hash).map(fromChunk)
+      }
+
+  def invalidate(hash: Hash): UIO[Unit] =
+    cache.invalidate(hash) *>
+      db.delete(hash.bytes.toArray).ignore
+
+object RocksDBCacheStore:
+  private def verify(hash: Hash, data: Chunk[Byte]): Task[Unit] =
+    for
+      dig <- Hashing.compute(Bytes(ZStream.fromChunk(data)), hash.algo)
+      _ <- ZIO
+        .fail(RuntimeException("hash mismatch"))
+        .unless(dig == hash.bytes)
+    yield ()
+
+  private def loader(
+      db: ZRocksDB,
+      ref: FiberRef[Hash => Task[Chunk[Byte]]]
+  )(hash: Hash): Task[Chunk[Byte]] =
+    val key = hash.bytes.toArray
+    def downloadAndStore: Task[Chunk[Byte]] =
+      for
+        remote <- ref.get
+        chunk <- remote(hash)
+        _ <- verify(hash, chunk)
+        _ <- db.put(key, chunk.toArray)
+      yield chunk
+    for
+      existing <- db.get(key)
+      chunk <- existing match
+        case Some(arr) =>
+          for
+            ok <- Hashing
+              .compute(
+                Bytes(ZStream.fromChunk(Chunk.fromArray(arr))),
+                hash.algo
+              )
+              .map(_ == hash.bytes)
+            res <-
+              if ok then ZIO.succeed(Chunk.fromArray(arr)) else downloadAndStore
+          yield res
+        case None => downloadAndStore
+    yield chunk
+
+  /** Construct a [[RocksDBCacheStore]]. */
+  def make(
+      path: Path,
+      capacity: Int = 1024,
+      ttl: Duration = Duration.Infinity
+  ): ZIO[Scope, Throwable, RocksDBCacheStore] =
+    for
+      env <- ZRocksDB.live(path.toString).build
+      db = env.get[ZRocksDB]
+      ref <- FiberRef.make[Hash => Task[Chunk[Byte]]]((_: Hash) =>
+        ZIO.fail(RuntimeException("no loader"))
+      )
+      cache <- Cache.make[Hash, Any, Throwable, Chunk[Byte]](
+        capacity,
+        ttl,
+        Lookup(loader(db, ref))
+      )
+    yield RocksDBCacheStore(db, cache, ref)
+
+  def layer(
+      path: Path,
+      capacity: Int = 1024,
+      ttl: Duration = Duration.Infinity
+  ): ZLayer[Any, Throwable, CacheStore] =
+    ZLayer.scoped(make(path, capacity, ttl))

--- a/modules/fs/src/test/scala/graviton/fs/DiskCacheStoreSpec.scala
+++ b/modules/fs/src/test/scala/graviton/fs/DiskCacheStoreSpec.scala
@@ -1,0 +1,51 @@
+package graviton.fs
+
+import graviton.*
+import zio.*
+import zio.stream.*
+import zio.test.*
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+import java.nio.file.Files
+
+object DiskCacheStoreSpec extends ZIOSpecDefault:
+
+  override def spec =
+    suite("DiskCacheStore")(
+      test("caches downloads when enabled") {
+        for
+          dir <- ZIO.attempt(Files.createTempDirectory("cache-test"))
+          store <- DiskCacheStore.make(dir)
+          ref <- Ref.make(0)
+          data = "hello".getBytes.toIndexedSeq
+          hashBytes <- Hashing.compute(
+            Bytes(ZStream.fromIterable(data)),
+            HashAlgorithm.SHA256
+          )
+          digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
+          hash = Hash(digest, HashAlgorithm.SHA256)
+          remote = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
+          _ <- store.fetch(hash, remote, useCache = true)
+          _ <- store.fetch(hash, remote, useCache = true)
+          calls <- ref.get
+        yield assertTrue(calls == 1)
+      },
+      test("bypasses cache when disabled") {
+        for
+          dir <- ZIO.attempt(Files.createTempDirectory("cache-test"))
+          store <- DiskCacheStore.make(dir)
+          ref <- Ref.make(0)
+          data = "hello".getBytes.toIndexedSeq
+          hashBytes <- Hashing.compute(
+            Bytes(ZStream.fromIterable(data)),
+            HashAlgorithm.SHA256
+          )
+          digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
+          hash = Hash(digest, HashAlgorithm.SHA256)
+          remote = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
+          _ <- store.fetch(hash, remote, useCache = false)
+          _ <- store.fetch(hash, remote, useCache = false)
+          calls <- ref.get
+        yield assertTrue(calls == 2)
+      }
+    )

--- a/modules/fs/src/test/scala/graviton/fs/RocksDBCacheStoreSpec.scala
+++ b/modules/fs/src/test/scala/graviton/fs/RocksDBCacheStoreSpec.scala
@@ -1,0 +1,97 @@
+package graviton.fs
+
+import graviton.*
+import zio.*
+import zio.stream.*
+import zio.test.*
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+import java.nio.file.Files
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+import zio.test.TestAspect
+
+class HttpEchoContainer
+    extends GenericContainer[HttpEchoContainer](
+      DockerImageName.parse("hashicorp/http-echo:1.0")
+    )
+
+object RocksDBCacheStoreSpec extends ZIOSpecDefault:
+
+  override def spec =
+    suite("RocksDBCacheStore")(
+      test("caches downloads when enabled") {
+        for
+          dir <- ZIO.attempt(Files.createTempDirectory("rocks-cache-test"))
+          store <- RocksDBCacheStore.make(dir)
+          ref <- Ref.make(0)
+          data = "hello".getBytes.toIndexedSeq
+          hashBytes <- Hashing.compute(
+            Bytes(ZStream.fromIterable(data)),
+            HashAlgorithm.SHA256
+          )
+          digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
+          hash = Hash(digest, HashAlgorithm.SHA256)
+          remote = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
+          _ <- store.fetch(hash, remote, useCache = true)
+          _ <- store.fetch(hash, remote, useCache = true)
+          calls <- ref.get
+        yield assertTrue(calls == 1)
+      },
+      test("bypasses cache when disabled") {
+        for
+          dir <- ZIO.attempt(Files.createTempDirectory("rocks-cache-test"))
+          store <- RocksDBCacheStore.make(dir)
+          ref <- Ref.make(0)
+          data = "hello".getBytes.toIndexedSeq
+          hashBytes <- Hashing.compute(
+            Bytes(ZStream.fromIterable(data)),
+            HashAlgorithm.SHA256
+          )
+          digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
+          hash = Hash(digest, HashAlgorithm.SHA256)
+          remote = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
+          _ <- store.fetch(hash, remote, useCache = false)
+          _ <- store.fetch(hash, remote, useCache = false)
+          calls <- ref.get
+        yield assertTrue(calls == 2)
+      },
+      test("caches downloads from external service") {
+        val acquire = ZIO.attempt {
+          val container = new HttpEchoContainer()
+            .withCommand("-text=hello")
+            .withExposedPorts(5678)
+          container.start()
+          container
+        }
+        val release = (c: GenericContainer[?]) => ZIO.attempt(c.stop()).ignore
+        ZIO.acquireRelease(acquire)(release).flatMap { c =>
+          val port = c.getMappedPort(5678)
+          val host = c.getHost
+          def fetchOnce: Task[Array[Byte]] =
+            ZIO.attemptBlockingIO {
+              val url = java.net.URI.create(s"http://$host:$port/").toURL
+              val in = url.openStream()
+              try in.readAllBytes()
+              finally in.close()
+            }
+          for
+            dir <- ZIO.attempt(Files.createTempDirectory("rocks-http-test"))
+            arr0 <- fetchOnce
+            hashBytes <- Hashing.compute(
+              Bytes(ZStream.fromIterable(arr0)),
+              HashAlgorithm.SHA256
+            )
+            digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
+            hash = Hash(digest, HashAlgorithm.SHA256)
+            ref <- Ref.make(0)
+            remote = ref.updateAndGet(_ + 1) *> fetchOnce
+              .map(arr => Bytes(ZStream.fromIterable(arr)))
+            store <- RocksDBCacheStore.make(dir)
+            _ <- store.fetch(hash, remote, useCache = true)
+            _ <- store.fetch(hash, remote, useCache = true)
+            calls <- ref.get
+          yield assertTrue(calls == 1)
+        }
+      } @@ TestAspect.ifEnvSet("TESTCONTAINERS")
+    )


### PR DESCRIPTION
## Summary
- add `CacheStore` abstraction with configurable bypass
- implement local `DiskCacheStore` backed by `zio-cache`
- implement persistent `RocksDBCacheStore` backed by `zio-rocksdb`
- cover caching and bypass behaviour for disk and RocksDB stores with tests, including a testcontainers-based external service check

## Testing
- `./sbt scalafmtAll test`


------
https://chatgpt.com/codex/tasks/task_b_68b83b495264832ea5a33e8d90458181