### PR TITLE
Add FileDescriptor schema and metadata validation

### DIFF
--- a/docs/src/main/mdoc/binary-store.md
+++ b/docs/src/main/mdoc/binary-store.md
@@ -76,5 +76,7 @@ module works with AWS S3 and other S3‑compatible endpoints such as MinIO.
 The attribute system has been consolidated around `graviton.core.BinaryAttributes`.
 The previous `AttributeName`/`BinaryAttributes` pair has been removed in favour of
 typed `BinaryAttributeKey`s, so downstream code should construct and query
-attributes using the new API.
+attributes using the new API. Binary attributes are now separated into
+`advertised` and `confirmed` sets, each recording the origin of the value via a
+`source` field.
 

--- a/docs/src/main/mdoc/file-descriptor-schema.md
+++ b/docs/src/main/mdoc/file-descriptor-schema.md
@@ -1,0 +1,11 @@
+# File Descriptor Schema
+
+The `FileDescriptor` manifest and its related key types are defined using
+`zio.schema.Schema`. These definitions act as the single source of truth and
+can be rendered to JSON Schema when needed.
+
+## Migration Notes
+
+Schema v1 introduces explicit validation for `filename` and content type
+attributes via `BinaryAttributes.validate`. Clients must ensure these
+attributes are well-formed or `put` operations will be rejected.

--- a/modules/core/src/main/scala/graviton/BlockKey.scala
+++ b/modules/core/src/main/scala/graviton/BlockKey.scala
@@ -1,8 +1,10 @@
 package graviton
 
-import io.github.iltotore.iron.*
-import io.github.iltotore.iron.constraint.all.*
+import zio.schema.{DeriveSchema, Schema}
 
-final case class BlockKey(hash: Hash, size: Int :| Positive)
+final case class BlockKey(hash: Hash, size: Int)
 
 final case class BlockKeySelector(prefix: Option[Array[Byte]] = None)
+
+object BlockKey:
+  given Schema[BlockKey] = DeriveSchema.gen[BlockKey]

--- a/modules/core/src/main/scala/graviton/FileDescriptor.scala
+++ b/modules/core/src/main/scala/graviton/FileDescriptor.scala
@@ -1,6 +1,7 @@
 package graviton
 
 import zio.Chunk
+import zio.schema.{DeriveSchema, Schema}
 
 final case class FileDescriptor(
     key: FileKey,
@@ -8,7 +9,6 @@ final case class FileDescriptor(
     blockSize: Int
 )
 
-final case class FileMetadata(
-    filename: Option[String],
-    advertisedMediaType: Option[String]
-)
+object FileDescriptor:
+  val SchemaVersion = 1
+  given Schema[FileDescriptor] = DeriveSchema.gen[FileDescriptor]

--- a/modules/core/src/main/scala/graviton/FileKey.scala
+++ b/modules/core/src/main/scala/graviton/FileKey.scala
@@ -1,13 +1,15 @@
 package graviton
 
-import io.github.iltotore.iron.*
-import io.github.iltotore.iron.constraint.all.*
+import zio.schema.{DeriveSchema, Schema}
 
 final case class FileKey(
     hash: Hash,
     algo: HashAlgorithm,
-    size: Long :| GreaterEqual[0],
+    size: Long,
     mediaType: String
 )
 
 final case class FileKeySelector(prefix: Option[Array[Byte]] = None)
+
+object FileKey:
+  given Schema[FileKey] = DeriveSchema.gen[FileKey]

--- a/modules/core/src/main/scala/graviton/FileStore.scala
+++ b/modules/core/src/main/scala/graviton/FileStore.scala
@@ -1,11 +1,12 @@
 package graviton
 
+import graviton.core.BinaryAttributes
 import zio.*
 import zio.stream.*
 
 trait FileStore:
   def put(
-      meta: FileMetadata,
+      attrs: BinaryAttributes,
       blockSize: Int
   ): ZSink[Any, Throwable, Byte, Nothing, FileKey]
   def get(key: FileKey): IO[Throwable, Option[Bytes]]

--- a/modules/core/src/main/scala/graviton/Hash.scala
+++ b/modules/core/src/main/scala/graviton/Hash.scala
@@ -1,13 +1,13 @@
 package graviton
 
 import zio.Chunk
-import io.github.iltotore.iron.*
-import io.github.iltotore.iron.constraint.all.*
+import zio.schema.{DeriveSchema, Schema}
 
-type Digest = Chunk[Byte] :| (MinLength[16] & MaxLength[64])
-
-final case class Hash(bytes: Digest, algo: HashAlgorithm):
+final case class Hash(bytes: Chunk[Byte], algo: HashAlgorithm):
   def hex: String =
     bytes
       .foldLeft(new StringBuilder) { (sb, b) => sb.append(f"$b%02x") }
       .toString
+
+object Hash:
+  given Schema[Hash] = DeriveSchema.gen[Hash]

--- a/modules/core/src/main/scala/graviton/HashAlgorithm.scala
+++ b/modules/core/src/main/scala/graviton/HashAlgorithm.scala
@@ -1,4 +1,90 @@
 package graviton
 
-enum HashAlgorithm:
-  case SHA256, SHA512, Blake3
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+import zio.schema.{DeriveSchema, Schema}
+
+/** Supported hashing algorithms for content addressed storage. Each algorithm
+  * exposes metadata about its digest and can compute hashes directly.
+  */
+sealed trait HashAlgorithm:
+  /** Canonical lowercase name of the algorithm. */
+  def canonicalName: String
+
+  /** Number of hex characters produced by this algorithm. */
+  def digestLength: Int
+
+  /** Obtain a new `MessageDigest` instance for this algorithm. */
+  protected def newDigest(): MessageDigest
+
+  /** Compute the digest for the provided data and return a lowercase hex
+    * string.
+    */
+  final def hash(data: Array[Byte]): String =
+    val md = newDigest()
+    val dig = md.digest(data)
+    val sb = new StringBuilder(dig.length * 2)
+    dig.foreach(b => sb.append(f"$b%02x"))
+    sb.toString
+
+  final def hash(data: String): String =
+    hash(data.getBytes(StandardCharsets.UTF_8))
+
+object HashAlgorithm:
+  case object Blake3 extends HashAlgorithm:
+    val canonicalName = "blake3"
+    val digestLength = 64
+    protected def newDigest(): MessageDigest = Blake3MessageDigest()
+
+  case object SHA256 extends HashAlgorithm:
+    val canonicalName = "sha256"
+    val digestLength = 64
+    protected def newDigest(): MessageDigest =
+      MessageDigest.getInstance("SHA-256")
+
+  case object SHA512 extends HashAlgorithm:
+    val canonicalName = "sha512"
+    val digestLength = 128
+    protected def newDigest(): MessageDigest =
+      MessageDigest.getInstance("SHA-512")
+
+  val values: List[HashAlgorithm] = List(Blake3, SHA256, SHA512)
+
+  private val aliases: Map[String, HashAlgorithm] =
+    values
+      .flatMap(a =>
+        List(a.canonicalName -> a, a.canonicalName.toUpperCase -> a)
+      )
+      .toMap
+
+  /** Parse a hash algorithm from a string, accepting canonical and uppercase
+    * names.
+    */
+  def parse(input: String): Either[String, HashAlgorithm] =
+    aliases.get(input).toRight(s"Unknown hash algorithm: $input")
+
+  given Schema[HashAlgorithm] = DeriveSchema.gen[HashAlgorithm]
+
+/** MessageDigest wrapper providing a `MessageDigest`-compatible interface for
+  * the Blake3 implementation which uses its own API.
+  */
+private final class Blake3MessageDigest extends MessageDigest("BLAKE3"):
+  import io.github.rctcwyvrn.blake3.Blake3
+
+  private var hasher = Blake3.newInstance()
+
+  override def engineUpdate(input: Byte): Unit =
+    hasher.update(Array(input)): Unit
+
+  override def engineUpdate(input: Array[Byte], offset: Int, len: Int): Unit =
+    val slice = java.util.Arrays.copyOfRange(input, offset, offset + len)
+    hasher.update(slice): Unit
+
+  override def engineDigest(): Array[Byte] =
+    val bytes = hasher.digest()
+    hasher = Blake3.newInstance()
+    bytes
+
+  override def engineReset(): Unit =
+    hasher = Blake3.newInstance()

--- a/modules/core/src/main/scala/graviton/core/BinaryAttributeKey.scala
+++ b/modules/core/src/main/scala/graviton/core/BinaryAttributeKey.scala
@@ -10,6 +10,8 @@ final case class BinaryAttributeKey[+A](id: String)(using
 object BinaryAttributeKey:
   val size: BinaryAttributeKey[Long] =
     BinaryAttributeKey[Long]("attr:size")(using Schema[Long])
+  val filename: BinaryAttributeKey[String] =
+    BinaryAttributeKey[String]("attr:filename")(using Schema[String])
   val contentType: BinaryAttributeKey[String] =
     BinaryAttributeKey[String]("attr:contentType")(using Schema[String])
   val createdAt: BinaryAttributeKey[Instant] =

--- a/modules/core/src/main/scala/graviton/core/BinaryAttributes.scala
+++ b/modules/core/src/main/scala/graviton/core/BinaryAttributes.scala
@@ -1,30 +1,92 @@
 package graviton.core
 
+import graviton.GravitonError
+import zio.*
 import zio.schema.*
-import zio.schema.codec.*
 import zio.schema.DynamicValue
 import scala.collection.immutable.ListMap
 
-final case class BinaryAttributes private (
-    values: ListMap[BinaryAttributeKey[?], DynamicValue]
-):
-  def get[A](k: BinaryAttributeKey[A])(using Schema[A]): Option[A] =
-    values.get(k).flatMap { dv =>
-      dv.toTypedValue(using Schema[A]).toOption
-    }
+final case class BinaryAttribute[A](value: A, source: String)
 
-  def put[A](k: BinaryAttributeKey[A], a: A)(using
-      Schema[A]
-  ): BinaryAttributes =
-    copy(values =
-      values.updated(k, DynamicValue.fromSchemaAndValue(Schema[A], a))
+private final case class DynamicAttr(value: DynamicValue, source: String):
+  def to[A](using Schema[A]): Option[BinaryAttribute[A]] =
+    value.toTypedValue(using Schema[A]).toOption.map(BinaryAttribute(_, source))
+
+private object DynamicAttr:
+  def from[A](attr: BinaryAttribute[A])(using Schema[A]): DynamicAttr =
+    DynamicAttr(
+      DynamicValue.fromSchemaAndValue(Schema[A], attr.value),
+      attr.source
     )
 
+final case class BinaryAttributes private (
+    advertised: ListMap[BinaryAttributeKey[?], DynamicAttr],
+    confirmed: ListMap[BinaryAttributeKey[?], DynamicAttr]
+):
+  def getAdvertised[A](k: BinaryAttributeKey[A])(using
+      Schema[A]
+  ): Option[BinaryAttribute[A]] =
+    advertised.get(k).flatMap(_.to[A])
+
+  def getConfirmed[A](k: BinaryAttributeKey[A])(using
+      Schema[A]
+  ): Option[BinaryAttribute[A]] =
+    confirmed.get(k).flatMap(_.to[A])
+
+  def putAdvertised[A](k: BinaryAttributeKey[A], attr: BinaryAttribute[A])(using
+      Schema[A]
+  ): BinaryAttributes =
+    copy(advertised = advertised.updated(k, DynamicAttr.from(attr)))
+
+  def putConfirmed[A](k: BinaryAttributeKey[A], attr: BinaryAttribute[A])(using
+      Schema[A]
+  ): BinaryAttributes =
+    copy(confirmed = confirmed.updated(k, DynamicAttr.from(attr)))
+
   def ++(other: BinaryAttributes): BinaryAttributes =
-    copy(values = values ++ other.values)
+    BinaryAttributes(
+      advertised ++ other.advertised,
+      confirmed ++ other.confirmed
+    )
 
 object BinaryAttributes:
-  val empty: BinaryAttributes = BinaryAttributes(ListMap.empty)
+  val empty: BinaryAttributes = BinaryAttributes(ListMap.empty, ListMap.empty)
 
-  def of[A](k: BinaryAttributeKey[A], a: A)(using Schema[A]): BinaryAttributes =
-    empty.put(k, a)
+  def advertised[A](k: BinaryAttributeKey[A], value: A, source: String)(using
+      Schema[A]
+  ): BinaryAttributes =
+    empty.putAdvertised(k, BinaryAttribute(value, source))
+
+  def confirmed[A](k: BinaryAttributeKey[A], value: A, source: String)(using
+      Schema[A]
+  ): BinaryAttributes =
+    empty.putConfirmed(k, BinaryAttribute(value, source))
+
+  private val FilenamePattern = "^[^\\/\\r\\n]+$".r
+  private val MediaTypePattern = "^[\\w.+-]+/[\\w.+-]+$".r
+
+  def validate(attrs: BinaryAttributes): IO[GravitonError, Unit] =
+    def validateAll(
+        values: List[String],
+        pattern: scala.util.matching.Regex,
+        msg: String
+    ): IO[GravitonError, Unit] =
+      ZIO.foreachDiscard(values) { v =>
+        if pattern.pattern.matcher(v).matches() then ZIO.unit
+        else ZIO.fail(GravitonError.PolicyViolation(msg))
+      }
+
+    val filenames = List(
+      attrs.getAdvertised(BinaryAttributeKey.filename).map(_.value),
+      attrs.getConfirmed(BinaryAttributeKey.filename).map(_.value)
+    ).flatten
+
+    val mediaTypes = List(
+      attrs.getAdvertised(BinaryAttributeKey.contentType).map(_.value),
+      attrs.getConfirmed(BinaryAttributeKey.contentType).map(_.value)
+    ).flatten
+
+    for
+      _ <- validateAll(filenames, FilenamePattern, "invalid filename")
+      _ <- validateAll(mediaTypes, MediaTypePattern, "invalid media type")
+    yield ()

--- a/modules/core/src/main/scala/graviton/core/BinaryKeyMatcher.scala
+++ b/modules/core/src/main/scala/graviton/core/BinaryKeyMatcher.scala
@@ -4,10 +4,12 @@ import zio.*
 import zio.schema.*
 import scala.collection.immutable.ListMap
 
+import graviton.HashAlgorithm
+
 sealed trait BinaryKeyMatcher
 object BinaryKeyMatcher:
   case object AnyKey extends BinaryKeyMatcher
-  final case class ByAlg(alg: BinaryKey.Alg) extends BinaryKeyMatcher
+  final case class ByAlg(alg: HashAlgorithm) extends BinaryKeyMatcher
   final case class ByCasPrefix(prefix: Chunk[Byte]) extends BinaryKeyMatcher
   final case class ByScope(prefix: ListMap[String, Option[String]])
       extends BinaryKeyMatcher


### PR DESCRIPTION
## Summary
- add zio.schema definitions for hash, keys, and file descriptors
- introduce typed BinaryAttributes with advertised/confirmed values and validation
- remove manual JSON schema file and document schema derivation
- refine BinaryKey hierarchy and implement sealed HashAlgorithm with Blake3 wrapper

## Testing
- `./sbt scalafmtAll`
- `./sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68b847ef1994832e9ab7069373a22474