### PR TITLE
Add ZIO logging with correlation IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,40 @@ curl http://localhost:8080/files/<fileKey> -o README.copy.md
 Documentation lives under the [docs](docs/src/main/mdoc/index.md) directory and
 is published as part of the project site.
 
+## Logging
+
+Graviton uses [ZIO Logging](https://zio.dev/reference/logging/) for structured
+output. Each major operation logs start, completion and any errors at `info` and
+`error` levels. A correlation ID is attached to every request so entries can be
+traced across layers.
+
+Loggers and log levels are configured via ZIO layers. For example, to route logs
+through SLF4J:
+
+```scala
+import zio.Runtime
+import zio.logging.backend.SLF4J
+
+val runtime = Runtime.removeDefaultLoggers >>> SLF4J.slf4j
+```
+
+The `ZIO_LOG_LEVEL` environment variable controls the minimum level emitted by
+the default console logger.
+
+For verifying log output in tests, use `ZTestLogger` to capture log entries:
+
+```scala
+import zio.test.ZTestLogger
+
+val program =
+  for
+    _     <- myBinaryStore.exists(BinaryId("1"))
+    logs  <- ZTestLogger.logOutput
+  yield assertTrue(logs.nonEmpty)
+
+program.provideLayer(ZTestLogger.default)
+```
+
 ## Development
 
 Integration tests that rely on Docker are gated behind the `TESTCONTAINERS`

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val zioMetricsV = "2.4.3"
 lazy val zioCacheV       = "0.2.4"
 lazy val zioRocksdbV     = "0.4.4"
 lazy val testContainersV = "1.19.7"
+lazy val zioLoggingV  = "2.2.4"
 
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
@@ -21,6 +22,7 @@ lazy val commonSettings = Seq(
     "dev.zio" %% "zio-schema-derivation" % zioSchemaV,
     "io.github.iltotore" %% "iron" % ironV,
     "io.github.rctcwyvrn" % "blake3" % "1.3",
+    "dev.zio" %% "zio-logging" % zioLoggingV,
     "dev.zio" %% "zio-test"          % zioV % Test,
     "dev.zio" %% "zio-test-sbt"      % zioV % Test,
     "dev.zio" %% "zio-test-magnolia" % zioV % Test

--- a/docs/src/main/mdoc/index.md
+++ b/docs/src/main/mdoc/index.md
@@ -11,6 +11,7 @@ Quasar and other applications.
 * **s3** – S3‑compatible blob store usable with AWS or MinIO.
 * **tika** – media type detection utilities backed by Apache Tika.
 * **metrics** – Prometheus instrumentation for core operations.
+* [Logging](logging.md) – structured logging with correlation IDs.
 * [Scan utilities](scan.md) – composable streaming transformers.
 
 See [architecture.md](architecture.md) for a high‑level overview of the storage

--- a/docs/src/main/mdoc/logging.md
+++ b/docs/src/main/mdoc/logging.md
@@ -1,0 +1,37 @@
+# Logging
+
+Graviton integrates ZIO Logging for structured output. Each major operation
+emits an `info` log when starting and finishing and an `error` log if the
+operation fails. A correlation ID is attached to all log entries so actions can
+be traced across different layers of the system.
+
+## Configuration
+
+Logging uses the standard ZIO Logging layers. The default runtime prints to the
+console and honors the `ZIO_LOG_LEVEL` environment variable. To route logs
+through SLF4J:
+
+```scala
+import zio.Runtime
+import zio.logging.backend.SLF4J
+
+val runtime = Runtime.removeDefaultLoggers >>> SLF4J.slf4j
+```
+
+Any other backend provided by ZIO Logging can be supplied in the same way.
+
+## Testing
+
+`ZTestLogger` captures log entries for assertions in unit tests:
+
+```scala
+import zio.test.ZTestLogger
+
+val effect =
+  for
+    _    <- myStore.exists(BinaryId("1"))
+    logs <- ZTestLogger.logOutput
+  yield assertTrue(logs.head.annotations.contains("correlation-id"))
+
+effect.provideLayer(ZTestLogger.default)
+```

--- a/modules/core/src/main/scala/graviton/logging/LoggingBinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/logging/LoggingBinaryStore.scala
@@ -1,0 +1,100 @@
+package graviton.logging
+
+import graviton.{BinaryId, BinaryStore, ByteRange}
+import graviton.core.BinaryAttributes
+import zio.*
+import zio.logging.logContext
+import zio.stream.*
+
+final case class LoggingBinaryStore(underlying: BinaryStore)
+    extends BinaryStore:
+  import LoggingBinaryStore.*
+
+  private def around[A](name: String)(fa: IO[Throwable, A]): IO[Throwable, A] =
+    loggingActive.get.flatMap {
+      case true => fa
+      case false =>
+        logContext.get.flatMap { ctx =>
+          ctx.get(cidKey) match
+            case Some(_) =>
+              loggingActive.locally(true) {
+                ZIO.logInfo(s"$name start") *> fa.tapBoth(
+                  err => ZIO.logErrorCause(s"$name error", Cause.fail(err)),
+                  _ => ZIO.logInfo(s"$name finish")
+                )
+              }
+            case None =>
+              Random.nextUUID.flatMap { cid =>
+                ZIO.logAnnotate(cidKey, cid.toString) {
+                  loggingActive.locally(true) {
+                    ZIO.logInfo(s"$name start") *> fa.tapBoth(
+                      err => ZIO.logErrorCause(s"$name error", Cause.fail(err)),
+                      _ => ZIO.logInfo(s"$name finish")
+                    )
+                  }
+                }
+              }
+        }
+    }
+
+  override def put(
+      attrs: BinaryAttributes,
+      chunkSize: Int
+  ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
+    ZSink.unwrapScoped {
+      loggingActive.get.flatMap {
+        case true => ZIO.succeed(underlying.put(attrs, chunkSize))
+        case false =>
+          logContext.get.flatMap { ctx =>
+            ctx.get(cidKey) match
+              case Some(_) =>
+                loggingActive.locally(true) {
+                  for
+                    _ <- ZIO.logInfo("put start")
+                    sink = underlying.put(attrs, chunkSize)
+                  yield sink
+                    .mapZIO(id => ZIO.logInfo("put finish").as(id))
+                    .mapErrorZIO(err =>
+                      ZIO.logErrorCause("put error", Cause.fail(err)).as(err)
+                    )
+                }
+              case None =>
+                Random.nextUUID.flatMap { cid =>
+                  ZIO.logAnnotate(cidKey, cid.toString) {
+                    loggingActive.locally(true) {
+                      for
+                        _ <- ZIO.logInfo("put start")
+                        sink = underlying.put(attrs, chunkSize)
+                      yield sink
+                        .mapZIO(id => ZIO.logInfo("put finish").as(id))
+                        .mapErrorZIO(err =>
+                          ZIO
+                            .logErrorCause("put error", Cause.fail(err))
+                            .as(err)
+                        )
+                    }
+                  }
+                }
+          }
+      }
+    }
+
+  override def get(
+      id: BinaryId,
+      range: Option[ByteRange]
+  ): IO[Throwable, Option[graviton.Bytes]] =
+    around("get")(underlying.get(id, range))
+
+  override def delete(id: BinaryId): IO[Throwable, Boolean] =
+    around("delete")(underlying.delete(id))
+
+  override def exists(id: BinaryId): IO[Throwable, Boolean] =
+    around("exists")(underlying.exists(id))
+
+object LoggingBinaryStore:
+  private val cidKey = "correlation-id"
+  val loggingActive: FiberRef[Boolean] =
+    Unsafe.unsafe { implicit u => FiberRef.unsafe.make(false) }
+
+  val layer: ZLayer[BinaryStore, Nothing, BinaryStore] =
+    ZLayer.fromFunction(LoggingBinaryStore(_))

--- a/modules/core/src/test/scala/graviton/logging/LoggingBinaryStoreSpec.scala
+++ b/modules/core/src/test/scala/graviton/logging/LoggingBinaryStoreSpec.scala
@@ -1,0 +1,39 @@
+package graviton.logging
+
+import graviton.{BinaryId, BinaryStore, ByteRange}
+import graviton.core.BinaryAttributes
+import zio.*
+import zio.stream.*
+import zio.test.*
+import zio.test.Assertion.*
+import zio.test.ZIOSpecDefault
+import zio.test.ZTestLogger
+
+object LoggingBinaryStoreSpec extends ZIOSpecDefault:
+  private val dummyStore = new BinaryStore:
+    def put(
+        attrs: BinaryAttributes,
+        chunkSize: Int
+    ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
+      ZSink.fail(new NotImplementedError("unused"))
+    def get(
+        id: BinaryId,
+        range: Option[ByteRange]
+    ): IO[Throwable, Option[graviton.Bytes]] =
+      ZIO.succeed(None)
+    def delete(id: BinaryId): IO[Throwable, Boolean] = ZIO.succeed(true)
+    def exists(id: BinaryId): IO[Throwable, Boolean] = ZIO.succeed(true)
+
+  def spec =
+    suite("LoggingBinaryStore")(
+      test("logs once when applied multiple times") {
+        val store = LoggingBinaryStore(LoggingBinaryStore(dummyStore))
+        for
+          _ <- store.exists(BinaryId("1"))
+          logs <- ZTestLogger.logOutput
+          start = logs.count(_.message() == "exists start")
+          finish = logs.count(_.message() == "exists finish")
+          ids = logs.map(_.annotations.get("correlation-id"))
+        yield assertTrue(start == 1, finish == 1, ids.flatten.toSet.size == 1)
+      }
+    ).provideLayer(ZTestLogger.default)


### PR DESCRIPTION
## Summary
- avoid duplicate logging via FiberRef guard
- document capturing logs with ZTestLogger
- test logging behavior

## Testing
- `sbt scalafmtAll`
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68b847e17748832ebe67620fd219c809