### PR TITLE
feat: integrate postgres codegen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,11 +6,14 @@ lazy val zioV        = "2.1.20"
 lazy val zioPreludeV = "1.0.0-RC41"
 lazy val ironV       = "3.2.0"
 lazy val zioSchemaV  = "1.7.4"
+lazy val zioJsonV    = "0.6.2"
 lazy val zioMetricsV = "2.4.3"
 lazy val zioCacheV       = "0.2.4"
 lazy val zioRocksdbV     = "0.4.4"
 lazy val testContainersV = "1.19.7"
 lazy val zioLoggingV  = "2.2.4"
+lazy val magnumV      = "2.0.0-M2"
+lazy val postgresV    = "42.7.3"
 
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
@@ -20,6 +23,7 @@ lazy val commonSettings = Seq(
     "dev.zio" %% "zio-prelude" % zioPreludeV,
     "dev.zio" %% "zio-schema"        % zioSchemaV,
     "dev.zio" %% "zio-schema-derivation" % zioSchemaV,
+    "dev.zio" %% "zio-json"          % zioJsonV,
     "io.github.iltotore" %% "iron" % ironV,
     "io.github.rctcwyvrn" % "blake3" % "1.3",
     "dev.zio" %% "zio-logging" % zioLoggingV,
@@ -30,7 +34,7 @@ lazy val commonSettings = Seq(
   testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
 )
 
-lazy val root = (project in file(".")).aggregate(core, fs, s3, tika, metrics, docs)
+lazy val root = (project in file(".")).aggregate(core, fs, s3, tika, metrics, pg, docs)
   .settings(name := "graviton")
 
 lazy val core = project
@@ -70,6 +74,20 @@ lazy val metrics = project
   .settings(
     name := "graviton-metrics",
     libraryDependencies += "dev.zio" %% "zio-metrics-connectors-prometheus" % zioMetricsV
+  )
+  .settings(commonSettings)
+
+lazy val pg = project
+  .in(file("modules/pg"))
+  .dependsOn(core)
+  .settings(
+    name := "graviton-pg",
+    libraryDependencies ++= Seq(
+      "com.augustnagro" %% "magnum" % magnumV,
+      "com.augustnagro" %% "magnumzio" % magnumV,
+      "org.postgresql" % "postgresql" % postgresV,
+      "org.testcontainers" % "postgresql" % testContainersV % Test
+    )
   )
   .settings(commonSettings)
 

--- a/modules/pg/codegen/magnum.ssp
+++ b/modules/pg/codegen/magnum.ssp
@@ -1,0 +1,51 @@
+<%@ val schema: dbcodegen.DataSchema %>
+
+package graviton.pg.generated
+
+import zio.Chunk
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.pg.enums.PgEnumDbCodec.given
+import com.augustnagro.magnum.pg.enums.PgEnumToScalaEnumSqlArrayCodec.given
+import graviton.pg.given
+
+#for (enum <- schema.enums)
+
+enum ${enum.scalaName} derives DbCodec:
+#for (enumValue <- enum.values)
+  @SqlName("${enumValue.name}")
+  case ${enumValue.scalaName}
+#end
+
+#end
+
+#for (table <- schema.tables)
+
+@Table(PostgresDbType)
+case class ${table.scalaName}(
+#for (column <- table.columns)
+#if (column.db.isPartOfPrimaryKey)
+  @Id
+#end
+  @SqlName("${column.name}")
+  ${column.scalaName}: ${column.scalaType},
+#end
+) derives DbCodec
+object ${table.scalaName}:
+#{ val primaryKeyColumns = table.columns.filter(_.db.isPartOfPrimaryKey)}#
+  type Id = ${if (primaryKeyColumns.isEmpty) "Null" else primaryKeyColumns.map(_.scalaType).mkString("(", ", ", ")")}
+
+#if (!table.isView)
+  case class Creator(
+#for (column <- table.columns if !column.db.isGenerated && !column.db.hasDefaultValue && !column.db.isAutoIncremented)
+    ${column.scalaName}: ${column.scalaType},
+#end
+  ) derives DbCodec
+#end
+
+#if (table.isView)
+val ${table.scalaName}Repo = ImmutableRepo[${table.scalaName}, ${table.scalaName}.Id]
+#else
+val ${table.scalaName}Repo = Repo[${table.scalaName}.Creator, ${table.scalaName}, ${table.scalaName}.Id]
+#end
+
+#end

--- a/modules/pg/ddl.sql
+++ b/modules/pg/ddl.sql
@@ -1,0 +1,131 @@
+-- ---- Domains / enums
+CREATE DOMAIN hash_bytes AS bytea CHECK (octet_length(VALUE) BETWEEN 16 AND 64);
+CREATE DOMAIN small_bytes AS bytea CHECK (octet_length(VALUE) <= 1048576); -- 1 MiB
+CREATE DOMAIN store_key AS bytea CHECK (octet_length(VALUE) = 32); -- 256-bit digest
+
+CREATE TYPE location_status AS ENUM ('active','stale','missing','deprecated','error');
+CREATE TYPE store_status    AS ENUM ('active','paused','retired');
+
+-- ---- Hash algorithms
+CREATE TABLE hash_algorithm (
+  id       SMALLSERIAL PRIMARY KEY,
+  name     TEXT UNIQUE NOT NULL,          -- 'blake3', 'sha256', ...
+  is_fips  BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+-- ---- Build info (current runtime; helps couple store keys to a build, if desired)
+CREATE TABLE build_info (
+  id            BIGSERIAL PRIMARY KEY,
+  app_name      TEXT NOT NULL,
+  version       TEXT NOT NULL,
+  git_sha       TEXT NOT NULL,            -- or digest bytes if you prefer
+  scala_version TEXT NOT NULL,
+  zio_version   TEXT NOT NULL,
+  built_at      TIMESTAMPTZ NOT NULL,
+  launched_at   TIMESTAMPTZ NOT NULL,
+  is_current    BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE UNIQUE INDEX build_info_one_current ON build_info (is_current) WHERE is_current;
+
+-- ---- BlobStore registry, keyed by canonical config
+CREATE TABLE blob_store (
+  key               store_key PRIMARY KEY,  -- 32 bytes: digest(impl_id || 0x00 || dv || 0x00 || build_fp)
+  impl_id           TEXT NOT NULL,          -- 's3','fs','ceph','rados','minio', ...
+  build_fp          bytea NOT NULL,         -- empty/zero if build-agnostic
+  dv_schema_urn     TEXT NOT NULL,          -- URI/URN for the Schema used to encode DV
+  dv_canonical_bin  bytea NOT NULL,         -- canonical DV bytes (stable codec)
+  dv_json_preview   JSONB,                  -- optional pretty/debug
+  status            store_status NOT NULL DEFAULT 'active',
+  version           BIGINT NOT NULL DEFAULT 0, -- bump to invalidate pool/caches
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX blob_store_status_idx ON blob_store (status);
+CREATE UNIQUE INDEX blob_store_uniqueness ON blob_store (impl_id, build_fp, dv_canonical_bin);
+
+-- ---- Block (CAS unit)
+CREATE TABLE block (
+  algo_id      SMALLINT NOT NULL REFERENCES hash_algorithm(id),
+  hash         hash_bytes NOT NULL,      -- raw digest only
+  size_bytes   BIGINT NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  inline_bytes small_bytes,              -- optional tiny payload
+  PRIMARY KEY (algo_id, hash)
+);
+CREATE INDEX block_size_idx ON block (size_bytes);
+
+-- ---- Block physical locations (many stores per block)
+CREATE TABLE block_location (
+  id                 BIGSERIAL PRIMARY KEY,
+  algo_id            SMALLINT NOT NULL,
+  hash               hash_bytes NOT NULL,
+  blob_store_key     store_key NOT NULL REFERENCES blob_store(key),
+  uri                TEXT,
+  status             location_status NOT NULL DEFAULT 'active',
+  bytes_length       BIGINT NOT NULL,
+  etag               TEXT,
+  storage_class      TEXT,
+  first_seen_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_verified_at   TIMESTAMPTZ,
+  UNIQUE (algo_id, hash, blob_store_key),
+  FOREIGN KEY (algo_id, hash) REFERENCES block(algo_id, hash) ON DELETE CASCADE
+);
+CREATE INDEX block_location_by_store_status ON block_location (blob_store_key, status);
+CREATE INDEX block_location_by_block       ON block_location (algo_id, hash);
+
+-- ---- File (ordered list of blocks, with its own digest)
+CREATE TABLE file (
+  id          UUID PRIMARY KEY,
+  algo_id     SMALLINT NOT NULL REFERENCES hash_algorithm(id),
+  hash        hash_bytes NOT NULL,
+  size_bytes  BIGINT NOT NULL,
+  media_type  TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (algo_id, hash, size_bytes)
+);
+
+CREATE TABLE file_block (
+  file_id        UUID NOT NULL REFERENCES file(id) ON DELETE CASCADE,
+  seq            INT  NOT NULL,
+  block_algo_id  SMALLINT NOT NULL,
+  block_hash     hash_bytes NOT NULL,
+  offset_bytes   BIGINT NOT NULL,
+  length_bytes   BIGINT NOT NULL,
+  PRIMARY KEY (file_id, seq),
+  FOREIGN KEY (block_algo_id, block_hash) REFERENCES block(algo_id, hash)
+);
+CREATE INDEX file_block_by_block ON file_block (block_algo_id, block_hash);
+
+-- ---- Merkle snapshots for sync/diff of Graviton slices (no Quasar)
+CREATE TABLE merkle_snapshot (
+  id                 BIGSERIAL PRIMARY KEY,
+  query_fingerprint  bytea NOT NULL,
+  algo_id            SMALLINT NOT NULL REFERENCES hash_algorithm(id),
+  root_hash          hash_bytes NOT NULL,
+  at_time            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  note               TEXT
+);
+CREATE UNIQUE INDEX merkle_unique_at ON merkle_snapshot (query_fingerprint, at_time);
+
+-- ---- LISTEN/NOTIFY invalidation for caches/pools
+CREATE OR REPLACE FUNCTION graviton_notify_change() RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify('graviton_inval', json_build_object(
+    'table', TG_TABLE_NAME, 'op', TG_OP, 'ts', now()
+  )::text);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER blob_store_inval_trg
+AFTER INSERT OR UPDATE OR DELETE ON blob_store FOR EACH ROW
+EXECUTE FUNCTION graviton_notify_change();
+
+CREATE TRIGGER block_inval_trg
+AFTER INSERT OR UPDATE OR DELETE ON block FOR EACH ROW
+EXECUTE FUNCTION graviton_notify_change();
+
+CREATE TRIGGER file_inval_trg
+AFTER INSERT OR UPDATE OR DELETE ON file FOR EACH ROW
+EXECUTE FUNCTION graviton_notify_change();
+

--- a/modules/pg/src/main/scala/com/augustnagro/magnum/pg/json/JsonBDbCodec.scala
+++ b/modules/pg/src/main/scala/com/augustnagro/magnum/pg/json/JsonBDbCodec.scala
@@ -1,0 +1,32 @@
+package com.augustnagro.magnum.pg.json
+
+import com.augustnagro.magnum.DbCodec
+import org.postgresql.util.PGobject
+
+import java.sql.{PreparedStatement, ResultSet, Types}
+
+trait JsonBDbCodec[A] extends DbCodec[A]:
+
+  def encode(a: A): String
+
+  def decode(json: String): A
+
+  override def queryRepr: String = "?"
+
+  override val cols: IArray[Int] = IArray(Types.OTHER)
+
+  override def readSingle(resultSet: ResultSet, pos: Int): A =
+    decode(resultSet.getString(pos))
+
+  override def readSingleOption(resultSet: ResultSet, pos: Int): Option[A] =
+    val rawJson = resultSet.getString(pos)
+    if rawJson == null then None
+    else Some(decode(rawJson))
+
+  override def writeSingle(entity: A, ps: PreparedStatement, pos: Int): Unit =
+    val jsonObject = PGobject()
+    jsonObject.setType("jsonb")
+    jsonObject.setValue(encode(entity))
+    ps.setObject(pos, jsonObject)
+
+end JsonBDbCodec

--- a/modules/pg/src/main/scala/graviton/pg/Canon.scala
+++ b/modules/pg/src/main/scala/graviton/pg/Canon.scala
@@ -1,0 +1,21 @@
+package graviton.pg
+
+import zio.Chunk
+import zio.schema.DynamicValue
+
+object Canon:
+  def canonicalize(dv: DynamicValue): Chunk[Byte] =
+    // Placeholder canonicalization
+    Chunk.empty
+
+  def storeKey(
+      implId: String,
+      dvCanon: Chunk[Byte],
+      buildFp: Chunk[Byte],
+      H: Chunk[Byte] => Chunk[Byte]
+  ): StoreKey =
+    val sep = Chunk.single(0.toByte)
+    val material = Chunk.fromArray(
+      implId.getBytes("UTF-8")
+    ) ++ sep ++ dvCanon ++ sep ++ buildFp
+    H(material).asInstanceOf[StoreKey]

--- a/modules/pg/src/main/scala/graviton/pg/Repos.scala
+++ b/modules/pg/src/main/scala/graviton/pg/Repos.scala
@@ -1,0 +1,183 @@
+package graviton.pg
+
+import zio.*
+import zio.Chunk
+import java.util.UUID
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.magzio.*
+
+trait BlobStoreRepo:
+  def upsert(row: BlobStoreRow): Task[Unit]
+  def get(key: StoreKey): Task[Option[BlobStoreRow]]
+  def listActive(): Task[Chunk[BlobStoreRow]]
+
+final class BlobStoreRepoLive(xa: Transactor) extends BlobStoreRepo:
+  def upsert(row: BlobStoreRow): Task[Unit] =
+    transact(xa) {
+      ZIO.attempt {
+        sql"""
+          INSERT INTO blob_store (key, impl_id, build_fp, dv_schema_urn, dv_canonical_bin, dv_json_preview, status)
+          VALUES (${row.key}, ${row.implId}, ${row.buildFp}, ${row.dvSchemaUrn}, ${row.dvCanonical}, ${row.dvJsonPreview}, ${row.status})
+          ON CONFLICT (key) DO UPDATE
+          SET updated_at = now(),
+              version    = blob_store.version + 1
+        """.update.run(); ()
+      }
+    }
+
+  def get(key: StoreKey): Task[Option[BlobStoreRow]] =
+    transact(xa) {
+      ZIO.attempt {
+        sql"""
+          SELECT key, impl_id, build_fp, dv_schema_urn, dv_canonical_bin, dv_json_preview, status, version
+          FROM blob_store WHERE key = $key
+        """.query[BlobStoreRow].run().headOption
+      }
+    }
+
+  def listActive(): Task[Chunk[BlobStoreRow]] =
+    transact(xa) {
+      ZIO.attempt {
+        val rows = sql"""
+          SELECT key, impl_id, build_fp, dv_schema_urn, dv_canonical_bin, dv_json_preview, status, version
+          FROM blob_store WHERE status = ${StoreStatus.Active}
+        """.query[BlobStoreRow].run()
+        Chunk.from(rows)
+      }
+    }
+
+object BlobStoreRepoLive:
+  val layer: ZLayer[Transactor, Nothing, BlobStoreRepo] =
+    ZLayer.fromFunction(new BlobStoreRepoLive(_))
+
+// ---- Block repository -------------------------------------------------------
+
+trait BlockRepo:
+  def upsertBlock(
+      key: BlockKey,
+      size: PosLong,
+      inline: Option[SmallBytes]
+  ): Task[Unit]
+  def getHead(key: BlockKey): Task[Option[(PosLong, Boolean)]]
+  def linkLocation(
+      key: BlockKey,
+      storeKey: StoreKey,
+      uri: Option[String],
+      len: PosLong,
+      etag: Option[String],
+      storageClass: Option[String]
+  ): Task[Unit]
+
+final class BlockRepoLive(xa: Transactor) extends BlockRepo:
+  def upsertBlock(
+      key: BlockKey,
+      size: PosLong,
+      inline: Option[SmallBytes]
+  ): Task[Unit] =
+    transact(xa) {
+      ZIO.attempt {
+        sql"""
+          INSERT INTO block (algo_id, hash, size_bytes, inline_bytes)
+          VALUES (${key.algoId}, ${key.hash}, $size, $inline)
+          ON CONFLICT (algo_id, hash) DO NOTHING
+        """.update.run(); ()
+      }
+    }
+
+  def getHead(key: BlockKey): Task[Option[(PosLong, Boolean)]] =
+    transact(xa) {
+      ZIO.attempt {
+        sql"""
+          SELECT size_bytes, (inline_bytes IS NOT NULL) AS has_inline
+          FROM block WHERE algo_id = ${key.algoId} AND hash = ${key.hash}
+        """.query[(Long, Boolean)].run().headOption.map { case (s, b) =>
+          (s.asInstanceOf[PosLong], b)
+        }
+      }
+    }
+
+  def linkLocation(
+      key: BlockKey,
+      storeKey: StoreKey,
+      uri: Option[String],
+      len: PosLong,
+      etag: Option[String],
+      storageClass: Option[String]
+  ): Task[Unit] =
+    transact(xa) {
+      ZIO.attempt {
+        sql"""
+          INSERT INTO block_location (algo_id, hash, blob_store_key, uri, status, bytes_length, etag, storage_class)
+          VALUES (${key.algoId}, ${key.hash}, $storeKey, $uri, ${LocationStatus.Active}, $len, $etag, $storageClass)
+          ON CONFLICT (algo_id, hash, blob_store_key) DO UPDATE
+          SET status = EXCLUDED.status,
+              bytes_length = EXCLUDED.bytes_length,
+              etag = EXCLUDED.etag,
+              storage_class = EXCLUDED.storage_class,
+              last_verified_at = now()
+        """.update.run(); ()
+      }
+    }
+
+object BlockRepoLive:
+  val layer: ZLayer[Transactor, Nothing, BlockRepo] =
+    ZLayer.fromFunction(new BlockRepoLive(_))
+
+// ---- File repository --------------------------------------------------------
+
+trait FileRepo:
+  def upsertFile(key: FileKey): Task[UUID]
+  def putFileBlocks(
+      fileId: UUID,
+      blocks: Chunk[(BlockKey, NonNegLong, PosLong)]
+  ): Task[Unit]
+  def findFileId(key: FileKey): Task[Option[UUID]]
+
+final class FileRepoLive(xa: Transactor) extends FileRepo:
+  def upsertFile(key: FileKey): Task[UUID] =
+    transact(xa) {
+      ZIO.attempt {
+        val id = UUID.randomUUID()
+        sql"""
+          INSERT INTO file (id, algo_id, hash, size_bytes, media_type)
+          VALUES ($id, ${key.algoId}, ${key.hash}, ${key.size}, ${key.mediaType})
+          ON CONFLICT (algo_id, hash, size_bytes) DO UPDATE
+          SET media_type = EXCLUDED.media_type
+          RETURNING id
+        """.query[UUID].run().head
+      }
+    }
+
+  def putFileBlocks(
+      fileId: UUID,
+      blocks: Chunk[(BlockKey, NonNegLong, PosLong)]
+  ): Task[Unit] =
+    transact(xa) {
+      ZIO.attempt {
+        blocks.zipWithIndex.foreach { case ((bk, offset, len), seq) =>
+          sql"""
+            INSERT INTO file_block (file_id, seq, block_algo_id, block_hash, offset_bytes, length_bytes)
+            VALUES ($fileId, $seq, ${bk.algoId}, ${bk.hash}, $offset, $len)
+            ON CONFLICT (file_id, seq) DO UPDATE
+            SET block_algo_id = EXCLUDED.block_algo_id,
+                block_hash    = EXCLUDED.block_hash,
+                offset_bytes  = EXCLUDED.offset_bytes,
+                length_bytes  = EXCLUDED.length_bytes
+          """.update.run()
+        }
+      }
+    }
+
+  def findFileId(key: FileKey): Task[Option[UUID]] =
+    transact(xa) {
+      ZIO.attempt {
+        sql"""
+          SELECT id FROM file
+          WHERE algo_id = ${key.algoId} AND hash = ${key.hash} AND size_bytes = ${key.size}
+        """.query[UUID].run().headOption
+      }
+    }
+
+object FileRepoLive:
+  val layer: ZLayer[Transactor, Nothing, FileRepo] =
+    ZLayer.fromFunction(new FileRepoLive(_))

--- a/modules/pg/src/main/scala/graviton/pg/model.scala
+++ b/modules/pg/src/main/scala/graviton/pg/model.scala
@@ -1,0 +1,75 @@
+package graviton.pg
+
+import zio.*
+import zio.Chunk
+import zio.json.*
+import zio.json.ast.Json
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.pg.json.JsonBDbCodec
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+
+type ExactLength[N <: Int] = Length[StrictEqual[N]]
+
+// ---- Refined byte types
+
+type HashBytes = Chunk[Byte] :| (MinLength[16] & MaxLength[64])
+type SmallBytes = Chunk[Byte] :| MaxLength[1048576]
+type StoreKey = Chunk[Byte] :| ExactLength[32]
+
+type PosLong = Long :| Positive
+type NonNegLong = Long :| Not[Negative]
+
+object Algo:
+  enum Id derives CanEqual, DbCodec:
+    case Blake3, Sha256, Sha1, Md5
+
+enum StoreStatus derives DbCodec:
+  @SqlName("active") case Active
+  @SqlName("paused") case Paused
+  @SqlName("retired") case Retired
+
+enum LocationStatus derives DbCodec:
+  @SqlName("active") case Active
+  @SqlName("stale") case Stale
+  @SqlName("missing") case Missing
+  @SqlName("deprecated") case Deprecated
+  @SqlName("error") case Error
+
+final case class BlockKey(algoId: Short, hash: HashBytes) derives DbCodec
+
+final case class FileKey(
+    algoId: Short,
+    hash: HashBytes,
+    size: PosLong,
+    mediaType: Option[String]
+) derives DbCodec
+
+final case class BlobStoreRow(
+    key: StoreKey,
+    implId: String,
+    buildFp: Chunk[Byte],
+    dvSchemaUrn: String,
+    dvCanonical: Chunk[Byte],
+    dvJsonPreview: Option[Json],
+    status: StoreStatus,
+    version: Long
+) derives DbCodec
+
+// ---- DbCodec instances for refined types
+
+given DbCodec[Chunk[Byte]] =
+  DbCodec[Array[Byte]].biMap(Chunk.fromArray, _.toArray)
+
+inline given [T, C](using DbCodec[T], Constraint[T, C]): DbCodec[T :| C] =
+  summon[DbCodec[T]].biMap(_.refineUnsafe[C], identity)
+
+given DbCodec[java.util.UUID] =
+  DbCodec[String].biMap(java.util.UUID.fromString, _.toString)
+
+given JsonBDbCodec[Json] with
+  def encode(a: Json): String = a.toJson
+  def decode(json: String): Json =
+    json
+      .fromJson[Json]
+      .fold(err => throw IllegalArgumentException(err), identity)

--- a/modules/pg/src/test/resources/ddl.sql
+++ b/modules/pg/src/test/resources/ddl.sql
@@ -1,0 +1,131 @@
+-- ---- Domains / enums
+CREATE DOMAIN hash_bytes AS bytea CHECK (octet_length(VALUE) BETWEEN 16 AND 64);
+CREATE DOMAIN small_bytes AS bytea CHECK (octet_length(VALUE) <= 1048576); -- 1 MiB
+CREATE DOMAIN store_key AS bytea CHECK (octet_length(VALUE) = 32); -- 256-bit digest
+
+CREATE TYPE location_status AS ENUM ('active','stale','missing','deprecated','error');
+CREATE TYPE store_status    AS ENUM ('active','paused','retired');
+
+-- ---- Hash algorithms
+CREATE TABLE hash_algorithm (
+  id       SMALLSERIAL PRIMARY KEY,
+  name     TEXT UNIQUE NOT NULL,          -- 'blake3', 'sha256', ...
+  is_fips  BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+-- ---- Build info (current runtime; helps couple store keys to a build, if desired)
+CREATE TABLE build_info (
+  id            BIGSERIAL PRIMARY KEY,
+  app_name      TEXT NOT NULL,
+  version       TEXT NOT NULL,
+  git_sha       TEXT NOT NULL,            -- or digest bytes if you prefer
+  scala_version TEXT NOT NULL,
+  zio_version   TEXT NOT NULL,
+  built_at      TIMESTAMPTZ NOT NULL,
+  launched_at   TIMESTAMPTZ NOT NULL,
+  is_current    BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE UNIQUE INDEX build_info_one_current ON build_info (is_current) WHERE is_current;
+
+-- ---- BlobStore registry, keyed by canonical config
+CREATE TABLE blob_store (
+  key               store_key PRIMARY KEY,  -- 32 bytes: digest(impl_id || 0x00 || dv || 0x00 || build_fp)
+  impl_id           TEXT NOT NULL,          -- 's3','fs','ceph','rados','minio', ...
+  build_fp          bytea NOT NULL,         -- empty/zero if build-agnostic
+  dv_schema_urn     TEXT NOT NULL,          -- URI/URN for the Schema used to encode DV
+  dv_canonical_bin  bytea NOT NULL,         -- canonical DV bytes (stable codec)
+  dv_json_preview   JSONB,                  -- optional pretty/debug
+  status            store_status NOT NULL DEFAULT 'active',
+  version           BIGINT NOT NULL DEFAULT 0, -- bump to invalidate pool/caches
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX blob_store_status_idx ON blob_store (status);
+CREATE UNIQUE INDEX blob_store_uniqueness ON blob_store (impl_id, build_fp, dv_canonical_bin);
+
+-- ---- Block (CAS unit)
+CREATE TABLE block (
+  algo_id      SMALLINT NOT NULL REFERENCES hash_algorithm(id),
+  hash         hash_bytes NOT NULL,      -- raw digest only
+  size_bytes   BIGINT NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  inline_bytes small_bytes,              -- optional tiny payload
+  PRIMARY KEY (algo_id, hash)
+);
+CREATE INDEX block_size_idx ON block (size_bytes);
+
+-- ---- Block physical locations (many stores per block)
+CREATE TABLE block_location (
+  id                 BIGSERIAL PRIMARY KEY,
+  algo_id            SMALLINT NOT NULL,
+  hash               hash_bytes NOT NULL,
+  blob_store_key     store_key NOT NULL REFERENCES blob_store(key),
+  uri                TEXT,
+  status             location_status NOT NULL DEFAULT 'active',
+  bytes_length       BIGINT NOT NULL,
+  etag               TEXT,
+  storage_class      TEXT,
+  first_seen_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_verified_at   TIMESTAMPTZ,
+  UNIQUE (algo_id, hash, blob_store_key),
+  FOREIGN KEY (algo_id, hash) REFERENCES block(algo_id, hash) ON DELETE CASCADE
+);
+CREATE INDEX block_location_by_store_status ON block_location (blob_store_key, status);
+CREATE INDEX block_location_by_block       ON block_location (algo_id, hash);
+
+-- ---- File (ordered list of blocks, with its own digest)
+CREATE TABLE file (
+  id          UUID PRIMARY KEY,
+  algo_id     SMALLINT NOT NULL REFERENCES hash_algorithm(id),
+  hash        hash_bytes NOT NULL,
+  size_bytes  BIGINT NOT NULL,
+  media_type  TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (algo_id, hash, size_bytes)
+);
+
+CREATE TABLE file_block (
+  file_id        UUID NOT NULL REFERENCES file(id) ON DELETE CASCADE,
+  seq            INT  NOT NULL,
+  block_algo_id  SMALLINT NOT NULL,
+  block_hash     hash_bytes NOT NULL,
+  offset_bytes   BIGINT NOT NULL,
+  length_bytes   BIGINT NOT NULL,
+  PRIMARY KEY (file_id, seq),
+  FOREIGN KEY (block_algo_id, block_hash) REFERENCES block(algo_id, hash)
+);
+CREATE INDEX file_block_by_block ON file_block (block_algo_id, block_hash);
+
+-- ---- Merkle snapshots for sync/diff of Graviton slices (no Quasar)
+CREATE TABLE merkle_snapshot (
+  id                 BIGSERIAL PRIMARY KEY,
+  query_fingerprint  bytea NOT NULL,
+  algo_id            SMALLINT NOT NULL REFERENCES hash_algorithm(id),
+  root_hash          hash_bytes NOT NULL,
+  at_time            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  note               TEXT
+);
+CREATE UNIQUE INDEX merkle_unique_at ON merkle_snapshot (query_fingerprint, at_time);
+
+-- ---- LISTEN/NOTIFY invalidation for caches/pools
+CREATE OR REPLACE FUNCTION graviton_notify_change() RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify('graviton_inval', json_build_object(
+    'table', TG_TABLE_NAME, 'op', TG_OP, 'ts', now()
+  )::text);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER blob_store_inval_trg
+AFTER INSERT OR UPDATE OR DELETE ON blob_store FOR EACH ROW
+EXECUTE FUNCTION graviton_notify_change();
+
+CREATE TRIGGER block_inval_trg
+AFTER INSERT OR UPDATE OR DELETE ON block FOR EACH ROW
+EXECUTE FUNCTION graviton_notify_change();
+
+CREATE TRIGGER file_inval_trg
+AFTER INSERT OR UPDATE OR DELETE ON file FOR EACH ROW
+EXECUTE FUNCTION graviton_notify_change();
+

--- a/modules/pg/src/test/scala/graviton/pg/BlobStoreRepoSpec.scala
+++ b/modules/pg/src/test/scala/graviton/pg/BlobStoreRepoSpec.scala
@@ -1,0 +1,65 @@
+package graviton.pg
+
+import zio.*
+import zio.test.*
+import zio.test.Assertion.*
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.magzio.*
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+
+object BlobStoreRepoSpec extends ZIOSpecDefault:
+
+  private val containerLayer: ZLayer[Any, Throwable, PostgreSQLContainer[?]] =
+    ZLayer.scoped {
+      ZIO.acquireRelease {
+        val c: PostgreSQLContainer[?] =
+          new PostgreSQLContainer(DockerImageName.parse("postgres:16-alpine"))
+            .withInitScript("ddl.sql")
+        c.start()
+        ZIO.succeed(c)
+      }(c => ZIO.succeed(c.stop()))
+    }
+
+  private val transactorLayer
+      : ZLayer[PostgreSQLContainer[?], Nothing, Transactor] =
+    ZLayer.fromZIO {
+      ZIO.service[PostgreSQLContainer[?]].map { c =>
+        val ds = new org.postgresql.ds.PGSimpleDataSource()
+        ds.setUrl(c.getJdbcUrl)
+        ds.setUser(c.getUsername)
+        ds.setPassword(c.getPassword)
+        Transactor(ds)
+      }
+    }
+
+  private val repoLayer =
+    containerLayer >>> transactorLayer >>> BlobStoreRepoLive.layer
+
+  private def sampleRow: BlobStoreRow =
+    val key: StoreKey = Chunk.fill(32)(1.toByte).asInstanceOf[StoreKey]
+    val bytes = Chunk.fromArray(Array[Byte](1, 2, 3))
+    BlobStoreRow(
+      key,
+      "fs",
+      bytes,
+      "urn:test",
+      bytes,
+      None,
+      StoreStatus.Active,
+      0L
+    )
+
+  def spec =
+    suite("BlobStoreRepo")(
+      test("upsert and fetch") {
+        for
+          repo <- ZIO.service[BlobStoreRepo]
+          row = sampleRow
+          _ <- repo.upsert(row)
+          got <- repo.get(row.key)
+        yield assertTrue(got.exists(_.implId == "fs"))
+      }
+    ).provideLayerShared(repoLayer)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.5.2")
+addSbtPlugin("com.github.cornerman" % "sbt-db-codegen" % "0.5.2")


### PR DESCRIPTION
## Summary
- apply Iron refined types and generic DbCodec mappings for Postgres models
- use typed enums in repository queries and link locations
- adapt BlobStore repo test to build refined StoreKey values

## Testing
- `./sbt test` *(failed: Could not find a valid Docker environment)*

------
https://chatgpt.com/codex/tasks/task_b_68b89e1830c4832e92074447de531b84