### PR TITLE
Support advanced Postgres types in dbcodegen

### DIFF
--- a/dbcodegen/src/main/scala/dbcodegen/DataSchema.scala
+++ b/dbcodegen/src/main/scala/dbcodegen/DataSchema.scala
@@ -1,0 +1,51 @@
+package dbcodegen
+
+import schemacrawler.schema.{Column, Index, Schema, Table, View}
+
+case class DataColumn(
+  name: String,
+  scalaType: String,
+  db: Column,
+) {
+  def scalaName = NameFormat.sanitizeScalaName(NameFormat.toCamelCase(name))
+}
+
+case class DataIndex(
+  name: String,
+  columns: Seq[DataColumn],
+  db: Index,
+) {
+  def scalaName = NameFormat.sanitizeScalaName(NameFormat.toPascalCase(name))
+}
+
+case class DataTable(
+  name: String,
+  columns: Seq[DataColumn],
+  indices: Seq[DataIndex],
+  db: Table,
+) {
+  def isView: Boolean = db.isInstanceOf[View]
+  def scalaName       = NameFormat.sanitizeScalaName(NameFormat.toPascalCase(name))
+}
+
+case class DataEnumValue(
+  name: String
+) {
+  def scalaName = NameFormat.sanitizeScalaName(name)
+}
+
+case class DataEnum(
+  name: String,
+  values: Seq[DataEnumValue],
+) {
+  def scalaName = NameFormat.sanitizeScalaName(NameFormat.toPascalCase(name))
+}
+
+case class DataSchema(
+  name: String,
+  tables: Seq[DataTable],
+  enums: Seq[DataEnum],
+  db: Schema,
+) {
+  def scalaName = NameFormat.sanitizeScalaName(NameFormat.toCamelCase(name))
+}

--- a/dbcodegen/src/main/scala/dbcodegen/PgTypeResolver.scala
+++ b/dbcodegen/src/main/scala/dbcodegen/PgTypeResolver.scala
@@ -1,0 +1,100 @@
+package dbcodegen
+
+import java.sql.{Connection, PreparedStatement, ResultSet}
+import scala.collection.mutable
+import scala.util.Using
+
+/** Resolves Postgres specific type information such as domains,
+  * enums, arrays and ranges by querying pg_catalog directly.
+  */
+object PgTypeResolver {
+  final case class ColumnInfo(
+      typtype: String,
+      typcategory: String,
+      typname: String,
+      arrayElemType: Option[String],
+      enumLabels: Option[Seq[String]],
+      rangeSubType: Option[String]
+  )
+
+  private val columnQuery =
+    """|
+       |WITH RECURSIVE col AS (
+       |  SELECT c.oid AS relid,
+       |         a.attnum,
+       |         a.attname AS column,
+       |         t.oid AS type_oid,
+       |         t.typtype,
+       |         t.typcategory,
+       |         t.typname,
+       |         t.typbasetype,
+       |         t.typelem,
+       |         0 AS depth
+       |  FROM pg_class c
+       |  JOIN pg_namespace n ON n.oid = c.relnamespace
+       |  JOIN pg_attribute a ON a.attrelid = c.oid
+       |  JOIN pg_type t ON t.oid = a.atttypid
+       |  WHERE n.nspname = ? AND c.relname = ? AND a.attnum > 0 AND NOT a.attisdropped
+       |  UNION ALL
+       |  SELECT col.relid, col.attnum, col.column,
+       |         base.oid, base.typtype, base.typcategory, base.typname,
+       |         base.typbasetype, base.typelem, col.depth + 1
+       |  FROM col
+       |  JOIN pg_type base ON col.typtype = 'd' AND base.oid = col.typbasetype
+       |),
+       |resolved AS (
+       |  SELECT DISTINCT ON (relid, attnum)
+       |    relid, attnum, column, type_oid, typtype, typcategory, typname, typelem
+       |  FROM col
+       |  ORDER BY relid, attnum, depth DESC
+       |)
+       |SELECT column,
+       |       typtype,
+       |       typcategory,
+       |       typname,
+       |       CASE WHEN typcategory = 'A' THEN format_type(typelem, NULL) END AS array_elem_type,
+       |       CASE WHEN typtype = 'r' THEN (
+       |         SELECT format_type(sub.oid, NULL)
+       |         FROM pg_range rg JOIN pg_type sub ON sub.oid = rg.rngsubtype
+       |         WHERE rg.rngtypid = type_oid
+       |       ) END AS range_subtype
+       |FROM resolved
+       |""".stripMargin
+
+  private val enumQuery =
+    "SELECT enumlabel FROM pg_type t JOIN pg_enum e ON e.enumtypid = t.oid WHERE t.typname = ? ORDER BY e.enumsortorder"
+
+  def resolveColumns(schema: String, table: String, source: Connection): Map[String, ColumnInfo] = {
+    val ps: PreparedStatement = source.prepareStatement(columnQuery)
+    ps.setString(1, schema)
+    ps.setString(2, table)
+    val rs = ps.executeQuery()
+    val buf = mutable.Map.empty[String, ColumnInfo]
+    while (rs.next()) {
+      val column        = rs.getString("column")
+      val typtype       = rs.getString("typtype")
+      val typcategory   = rs.getString("typcategory")
+      val typname       = rs.getString("typname")
+      val arrayElemType = Option(rs.getString("array_elem_type"))
+      val rangeSubtype  = Option(rs.getString("range_subtype"))
+      val enumLabels =
+        enumLabelsFor(if (typtype == "e") typname else arrayElemType.orNull, source)
+      buf += column -> ColumnInfo(typtype, typcategory, typname, arrayElemType, enumLabels, rangeSubtype)
+    }
+    rs.close()
+    ps.close()
+    buf.toMap
+  }
+
+  private def enumLabelsFor(tpe: String, conn: Connection): Option[Seq[String]] =
+    Option(tpe).flatMap { name =>
+      val ps   = conn.prepareStatement(enumQuery)
+      ps.setString(1, name)
+      val rs   = ps.executeQuery()
+      val list = mutable.ListBuffer.empty[String]
+      while (rs.next()) list += rs.getString(1)
+      rs.close()
+      ps.close()
+      if (list.isEmpty) None else Some(list.toList)
+    }
+}

--- a/dbcodegen/src/main/scala/dbcodegen/SchemaConverter.scala
+++ b/dbcodegen/src/main/scala/dbcodegen/SchemaConverter.scala
@@ -1,0 +1,174 @@
+package dbcodegen
+
+import schemacrawler.crawl.SchemaCrawlerExt
+import schemacrawler.schema._
+import schemacrawler.tools.utility.SchemaCrawlerUtility
+import us.fatehi.utility.datasource.DatabaseConnectionSource
+
+import java.sql.{JDBCType, SQLType, Types}
+import scala.jdk.CollectionConverters._
+import scala.reflect.{classTag, ClassTag}
+import scala.util.Try
+
+object SchemaConverter {
+  def toDataSchema(
+    schema: Schema,
+    connection: DatabaseConnectionSource,
+    schemaTables: Seq[Table],
+    config: CodeGeneratorConfig,
+  ): DataSchema = {
+    val schemaName = Option(schema.getName).filter(_.nonEmpty).getOrElse("schema")
+
+    val (tables, enums) = schemaTables.collect {
+      case table if config.schemaTableFilter(schemaName, table.getName) =>
+        val usableColumns = table.getColumns.asScala.filter(column => !column.isHidden)
+
+        val pgColumnInfo = {
+          val conn = connection.get()
+          try PgTypeResolver.resolveColumns(schemaName, table.getName, conn)
+          finally connection.releaseConnection(conn)
+        }
+
+        val (columns, columnEnums) = usableColumns.collect { case column =>
+          val pgInfo                 = pgColumnInfo.get(column.getName)
+          val (scalaType, dataEnum) = columnToScalaType(schema, connection, column, pgInfo, config)
+          val dataColumn = DataColumn(
+            column.getName,
+            scalaType,
+            column,
+          )
+
+          (dataColumn, dataEnum)
+        }.unzip
+
+        val columnsMap = columns.map(c => c.name -> c).toMap
+
+        val indices = table.getIndexes.asScala.map { index =>
+          val indexColumns = index.getColumns.asScala.flatMap(column => columnsMap.get(column.getName))
+
+          DataIndex(
+            index.getShortName.stripPrefix(table.getName + "."),
+            indexColumns.toSeq,
+            index,
+          )
+        }
+
+        val dataTable = DataTable(
+          table.getName,
+          columns.toSeq,
+          indices.toSeq,
+          table,
+        )
+
+        (dataTable, columnEnums)
+    }.unzip
+
+    DataSchema(
+      schemaName,
+      tables.distinct,
+      enums.flatMap(_.flatten).distinct,
+      schema,
+    )
+  }
+
+  def columnToScalaType(
+    schema: Schema,
+    connection: DatabaseConnectionSource,
+    column: Column,
+    pgInfo: Option[PgTypeResolver.ColumnInfo],
+    config: CodeGeneratorConfig,
+  ): (String, Option[DataEnum]) = {
+    pgInfo match {
+      case Some(info) =>
+        info.enumLabels match {
+          case Some(labels) =>
+            val enumName = info.arrayElemType.getOrElse(info.typname)
+            val dataEnum = DataEnum(enumName, labels.map(DataEnumValue(_)))
+            val base     = dataEnum.scalaName
+            val withArr  = if (info.typcategory == "A") s"Vector[$base]" else base
+            val scalaT   = if (column.isNullable && !column.isPartOfPrimaryKey) s"Option[$withArr]" else withArr
+            (scalaT, Some(dataEnum))
+          case None =>
+            val typeName = info.arrayElemType.orElse(info.rangeSubType).getOrElse(info.typname)
+            val targetType = localTypeNameToSqlType(typeName).getOrElse(column.getColumnDataType.getJavaSqlType)
+            val scalaTypeClassGuess   = sqlToScalaType(targetType)
+            val scalaTypeStringGuess  = scalaTypeClassGuess.map(_.toString.replaceFirst("java\\.lang\\.", ""))
+            val scalaTypeString       =
+              config.typeMapping(targetType, scalaTypeStringGuess).getOrElse(throw new Exception(s"Cannot map sql type '$targetType'"))
+            val withRange = if (info.rangeSubType.isDefined) s"PgRange[$scalaTypeString]" else scalaTypeString
+            val withArr   = if (info.typcategory == "A") s"Vector[$withRange]" else withRange
+            val scalaT    = if (column.isNullable && !column.isPartOfPrimaryKey) s"Option[$withArr]" else withArr
+            (scalaT, None)
+        }
+      case None =>
+        val tpe = column.getColumnDataType
+        val (enumValues, arrayElementType) = (tpe.getJavaSqlType.getVendorTypeNumber.intValue(), tpe.getName) match {
+          case (Types.ARRAY, elementTypeString) if elementTypeString.startsWith("_") =>
+            val elementType            = elementTypeString.stripPrefix("_")
+            val columnDataType         = SchemaCrawlerExt.newColumnDataType(schema, elementType, DataTypeType.system)
+            val conn                   = connection.get()
+            val schemaRetrievalOptions = SchemaCrawlerUtility.matchSchemaRetrievalOptions(connection)
+            val enumType               = schemaRetrievalOptions.getEnumDataTypeHelper.getEnumDataTypeInfo(column, columnDataType, conn)
+            connection.releaseConnection(conn)
+            (enumType.getEnumValues, Some(elementType))
+          case (_, _) =>
+            (tpe.getEnumValues, None)
+        }
+
+        val (baseScalaType, dataEnum) = enumValues match {
+          case enumValues if enumValues.isEmpty =>
+            val targetType =
+              arrayElementType.flatMap(localTypeNameToSqlType).orElse(localTypeNameToSqlType(tpe.getName)).getOrElse(tpe.getJavaSqlType)
+            val scalaTypeClassGuess   = sqlToScalaType(targetType)
+            val scalaTypeStringGuess  = scalaTypeClassGuess.map(_.toString.replaceFirst("java\\.lang\\.", ""))
+            val scalaTypeStringMapped = config.typeMapping(targetType, scalaTypeStringGuess)
+            val scalaTypeString       = scalaTypeStringMapped.getOrElse(throw new Exception(s"Cannot map sql type '${targetType}'"))
+            (scalaTypeString, None)
+          case enumValues =>
+            val targetTypeName = arrayElementType.getOrElse(tpe.getName)
+            val dataEnum       = DataEnum(targetTypeName, enumValues.asScala.map(DataEnumValue(_)).toSeq)
+            (dataEnum.scalaName, Some(dataEnum))
+        }
+
+        val scalaTypeWithArray = if (arrayElementType.isDefined) s"Vector[$baseScalaType]" else baseScalaType
+        val scalaType          = if (column.isNullable && !column.isPartOfPrimaryKey) s"Option[$scalaTypeWithArray]" else scalaTypeWithArray
+        (scalaType, dataEnum)
+    }
+  }
+
+  def sqlToScalaType(tpe: SQLType): Option[ClassTag[?]] = Some(tpe.getVendorTypeNumber.intValue()).collect {
+    case Types.OTHER | Types.VARCHAR | Types.CHAR | Types.LONGVARCHAR | Types.NVARCHAR | Types.LONGNVARCHAR => classTag[String]
+    case Types.BOOLEAN | Types.BIT                                                                          => classTag[Boolean]
+    case Types.INTEGER                                                                                      => classTag[Int]
+    case Types.TINYINT                                                                                      => classTag[Byte]
+    case Types.SMALLINT                                                                                     => classTag[Short]
+    case Types.BIGINT                                                                                       => classTag[Long]
+    case Types.REAL | Types.FLOAT | Types.DOUBLE                                                            => classTag[Double]
+    case Types.DECIMAL | Types.NUMERIC                                                                      => classTag[java.math.BigDecimal]
+    case Types.TIME                                                                                         => classTag[java.time.LocalTime]
+    case Types.DATE                                                                                         => classTag[java.time.LocalDate]
+    case Types.TIMESTAMP                                                                                    => classTag[java.time.LocalDateTime]
+    case Types.TIME_WITH_TIMEZONE                                                                           => classTag[java.time.OffsetTime]
+    case Types.TIMESTAMP_WITH_TIMEZONE                                                                      => classTag[java.time.OffsetDateTime]
+    case Types.BLOB | Types.VARBINARY | Types.LONGVARBINARY | Types.BINARY                                  => classTag[java.sql.Blob]
+    case Types.CLOB                                                                                         => classTag[java.sql.Clob]
+    case Types.NCLOB                                                                                        => classTag[java.sql.NClob]
+    case Types.ROWID                                                                                        => classTag[java.sql.RowId]
+    case Types.ARRAY                                                                                        => classTag[java.sql.Array]
+    case Types.STRUCT                                                                                       => classTag[java.sql.Struct]
+    case Types.DATALINK                                                                                     => classTag[java.net.URL]
+  }
+
+  def localTypeNameToSqlType(localTypeName: String): Option[SQLType] = localTypeName.toUpperCase match {
+    // TODO: specific to Postgres
+    case "TEXT" | "UUID"  => Some(JDBCType.LONGVARCHAR)
+    case "JSON" | "JSONB" => Some(JDBCType.OTHER)
+    case "INT2"           => Some(JDBCType.SMALLINT)
+    case "INT" | "INT4"   => Some(JDBCType.INTEGER)
+    case "INT8"           => Some(JDBCType.BIGINT)
+    case "FLOAT4"         => Some(JDBCType.FLOAT)
+    case "FLOAT8"         => Some(JDBCType.DOUBLE)
+    case "MONEY"          => Some(JDBCType.DECIMAL)
+    case other            => Try(JDBCType.valueOf(other)).toOption
+  }
+}

--- a/modules/pg/codegen/magnum.ssp
+++ b/modules/pg/codegen/magnum.ssp
@@ -7,6 +7,7 @@ import com.augustnagro.magnum.*
 import com.augustnagro.magnum.pg.enums.PgEnumDbCodec.given
 import com.augustnagro.magnum.pg.enums.PgEnumToScalaEnumSqlArrayCodec.given
 import graviton.pg.given
+import graviton.pg.PgRange
 
 #for (enum <- schema.enums)
 

--- a/modules/pg/src/main/scala/graviton/pg/PgRange.scala
+++ b/modules/pg/src/main/scala/graviton/pg/PgRange.scala
@@ -1,0 +1,4 @@
+package graviton.pg
+
+/** Simple representation of a PostgreSQL range type. */
+final case class PgRange[T](lower: Option[T], upper: Option[T])

--- a/modules/pg/src/test/scala/graviton/pg/PgTestLayers.scala
+++ b/modules/pg/src/test/scala/graviton/pg/PgTestLayers.scala
@@ -31,7 +31,8 @@ object PgTestLayers:
         java.lang.System.setProperty("com.zaxxer.hikari.level", "DEBUG")
 
         val ds = new HikariDataSource()
-        ds.setJdbcUrl(c.getJdbcUrl)
+        // use 127.0.0.1 instead of localhost for deterministic host resolution
+        ds.setJdbcUrl(c.getJdbcUrl.replace("localhost", "127.0.0.1"))
         ds.setUsername(c.getUsername)
         ds.setPassword(c.getPassword)
         ds.setMaximumPoolSize(4)


### PR DESCRIPTION
## Summary
- add Postgres catalog resolver to discover domains, enums, arrays, and ranges
- integrate resolver into SchemaConverter and expose PgRange wrapper
- import PgRange in codegen template for generated sources
- direct tests to connect to Postgres via 127.0.0.1

## Testing
- `./sbt core/test`
- `./sbt fs/test`
- `./sbt pg/test` *(fails: Could not connect to `jdbc:postgresql://localhost:5432/postgres`)*


------
https://chatgpt.com/codex/tasks/task_b_68b926416b48832e993e4dfb00c1567d