### PR TITLE
Fix pg test init script handling

### DIFF
--- a/modules/core/src/main/scala/graviton/BinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/BinaryStore.scala
@@ -6,12 +6,12 @@ import zio.stream.*
 
 trait BinaryStore:
   def put(
-      attrs: BinaryAttributes,
-      chunkSize: Int
+    attrs: BinaryAttributes,
+    chunkSize: Int,
   ): ZSink[Any, Throwable, Byte, Nothing, BinaryId]
   def get(
-      id: BinaryId,
-      range: Option[ByteRange] = None
+    id: BinaryId,
+    range: Option[ByteRange] = None,
   ): IO[Throwable, Option[Bytes]]
   def delete(id: BinaryId): IO[Throwable, Boolean]
   def exists(id: BinaryId): IO[Throwable, Boolean]

--- a/modules/core/src/main/scala/graviton/BlobStore.scala
+++ b/modules/core/src/main/scala/graviton/BlobStore.scala
@@ -4,12 +4,12 @@ import zio.*
 
 trait BlobStore:
   def id: BlobStoreId
-  
+
   def status: UIO[BlobStoreStatus]
 
   def read(
-      key: BlockKey,
-      range: Option[ByteRange] = None
+    key: BlockKey,
+    range: Option[ByteRange] = None,
   ): IO[Throwable, Option[Bytes]]
 
   def write(key: BlockKey, data: Bytes): Task[Unit]

--- a/modules/core/src/main/scala/graviton/BlockSector.scala
+++ b/modules/core/src/main/scala/graviton/BlockSector.scala
@@ -1,6 +1,6 @@
 package graviton
 
 final case class BlockSector(
-    blobStoreId: BlobStoreId,
-    status: BlobStoreStatus
+  blobStoreId: BlobStoreId,
+  status: BlobStoreStatus,
 )

--- a/modules/core/src/main/scala/graviton/BlockStore.scala
+++ b/modules/core/src/main/scala/graviton/BlockStore.scala
@@ -6,8 +6,8 @@ import zio.stream.*
 trait BlockStore:
   def put: ZSink[Any, Throwable, Byte, Nothing, BlockKey]
   def get(
-      key: BlockKey,
-      range: Option[ByteRange] = None
+    key: BlockKey,
+    range: Option[ByteRange] = None,
   ): IO[Throwable, Option[Bytes]]
   def has(key: BlockKey): IO[Throwable, Boolean]
   def delete(key: BlockKey): IO[Throwable, Boolean]

--- a/modules/core/src/main/scala/graviton/CacheStore.scala
+++ b/modules/core/src/main/scala/graviton/CacheStore.scala
@@ -2,26 +2,28 @@ package graviton
 
 import zio.*
 
-/** Simple abstraction for caching binary content by [[Hash]]. Implementations
-  * must verify that any cached data matches the requested hash before serving
-  * it and fall back to the provided download effect when the cache is absent or
-  * invalid.
-  */
+/**
+ * Simple abstraction for caching binary content by [[Hash]]. Implementations
+ * must verify that any cached data matches the requested hash before serving
+ * it and fall back to the provided download effect when the cache is absent or
+ * invalid.
+ */
 trait CacheStore:
-  /** Retrieve data for the supplied [[Hash]].
-    *
-    * @param hash
-    *   expected hash of the content
-    * @param download
-    *   effect producing the content when it is not cached or the cached value
-    *   is invalid
-    * @param useCache
-    *   when `false`, caching is bypassed and `download` is always executed
-    */
+  /**
+   * Retrieve data for the supplied [[Hash]].
+   *
+   * @param hash
+   *   expected hash of the content
+   * @param download
+   *   effect producing the content when it is not cached or the cached value
+   *   is invalid
+   * @param useCache
+   *   when `false`, caching is bypassed and `download` is always executed
+   */
   def fetch(
-      hash: Hash,
-      download: => Task[Bytes],
-      useCache: Boolean = true
+    hash: Hash,
+    download: => Task[Bytes],
+    useCache: Boolean = true,
   ): Task[Bytes]
 
   /** Remove any cached value associated with the supplied hash. */

--- a/modules/core/src/main/scala/graviton/ChunkedBinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/ChunkedBinaryStore.scala
@@ -5,7 +5,7 @@ import graviton.core.BinaryAttributes
 import zio.stream.*
 
 trait ChunkedBinaryStore:
-  
+
   def insertChunks(
-      attrs: BinaryAttributes
+    attrs: BinaryAttributes
   ): ZSink[Any, Throwable, ChunkDef, Nothing, InsertChunkResult]

--- a/modules/core/src/main/scala/graviton/CopyTool.scala
+++ b/modules/core/src/main/scala/graviton/CopyTool.scala
@@ -4,8 +4,8 @@ import zio.*
 
 trait CopyTool:
   def copy(
-      src: BinaryStore,
-      dest: BinaryStore,
-      id: BinaryId,
-      hint: Option[Hint] = None
+    src: BinaryStore,
+    dest: BinaryStore,
+    id: BinaryId,
+    hint: Option[Hint] = None,
   ): IO[Throwable, Unit]

--- a/modules/core/src/main/scala/graviton/Encryption.scala
+++ b/modules/core/src/main/scala/graviton/Encryption.scala
@@ -17,9 +17,9 @@ object Encryption:
 
     // RFC 5869 HKDF inspired by zio-crypto's implementation
     private def hkdf(
-        master: Array[Byte],
-        salt: Array[Byte],
-        length: Int
+      master: Array[Byte],
+      salt: Array[Byte],
+      length: Int,
     ): Array[Byte] =
       val mac = Mac.getInstance("HmacSHA256")
       mac.init(new SecretKeySpec(salt, "HmacSHA256"))
@@ -39,7 +39,7 @@ object Encryption:
       ZIO.attempt {
         val secret = new SecretKeySpec(deriveKey(hash), "AES")
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-        val spec = new GCMParameterSpec(128, nonce(hash))
+        val spec   = new GCMParameterSpec(128, nonce(hash))
         cipher.init(Cipher.ENCRYPT_MODE, secret, spec)
         Chunk.fromArray(cipher.doFinal(data.toArray))
       }
@@ -48,10 +48,10 @@ object Encryption:
       ZIO.attempt {
         val secret = new SecretKeySpec(deriveKey(hash), "AES")
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-        val spec = new GCMParameterSpec(128, nonce(hash))
+        val spec   = new GCMParameterSpec(128, nonce(hash))
         cipher.init(Cipher.DECRYPT_MODE, secret, spec)
         Chunk.fromArray(cipher.doFinal(data.toArray))
       }
 
   val live: ZLayer[MasterKey, Nothing, Encryption] =
-    ZLayer.fromFunction { (mk: MasterKey) => new AesGcm(mk.bytes) }
+    ZLayer.fromFunction((mk: MasterKey) => new AesGcm(mk.bytes))

--- a/modules/core/src/main/scala/graviton/FileDescriptor.scala
+++ b/modules/core/src/main/scala/graviton/FileDescriptor.scala
@@ -4,11 +4,11 @@ import zio.Chunk
 import zio.schema.{DeriveSchema, Schema}
 
 final case class FileDescriptor(
-    key: FileKey,
-    blocks: Chunk[BlockKey],
-    blockSize: Int
+  key: FileKey,
+  blocks: Chunk[BlockKey],
+  blockSize: Int,
 )
 
 object FileDescriptor:
-  val SchemaVersion = 1
+  val SchemaVersion            = 1
   given Schema[FileDescriptor] = DeriveSchema.gen[FileDescriptor]

--- a/modules/core/src/main/scala/graviton/FileKey.scala
+++ b/modules/core/src/main/scala/graviton/FileKey.scala
@@ -3,10 +3,10 @@ package graviton
 import zio.schema.{DeriveSchema, Schema}
 
 final case class FileKey(
-    hash: Hash,
-    algo: HashAlgorithm,
-    size: Long,
-    mediaType: String
+  hash: Hash,
+  algo: HashAlgorithm,
+  size: Long,
+  mediaType: String,
 )
 
 final case class FileKeySelector(prefix: Option[Array[Byte]] = None)

--- a/modules/core/src/main/scala/graviton/FileStore.scala
+++ b/modules/core/src/main/scala/graviton/FileStore.scala
@@ -6,8 +6,8 @@ import zio.stream.*
 
 trait FileStore:
   def put(
-      attrs: BinaryAttributes,
-      blockSize: Int
+    attrs: BinaryAttributes,
+    blockSize: Int,
   ): ZSink[Any, Throwable, Byte, Nothing, FileKey]
   def get(key: FileKey): IO[Throwable, Option[Bytes]]
   def describe(key: FileKey): IO[Throwable, Option[FileDescriptor]]

--- a/modules/core/src/main/scala/graviton/GravitonError.scala
+++ b/modules/core/src/main/scala/graviton/GravitonError.scala
@@ -2,15 +2,7 @@ package graviton
 
 sealed trait GravitonError extends Throwable
 object GravitonError:
-  final case class NotFound(msg: String)
-      extends Exception(msg)
-      with GravitonError
-  final case class BackendUnavailable(msg: String)
-      extends Exception(msg)
-      with GravitonError
-  final case class CorruptData(msg: String)
-      extends Exception(msg)
-      with GravitonError
-  final case class PolicyViolation(msg: String)
-      extends Exception(msg)
-      with GravitonError
+  final case class NotFound(msg: String)           extends Exception(msg) with GravitonError
+  final case class BackendUnavailable(msg: String) extends Exception(msg) with GravitonError
+  final case class CorruptData(msg: String)        extends Exception(msg) with GravitonError
+  final case class PolicyViolation(msg: String)    extends Exception(msg) with GravitonError

--- a/modules/core/src/main/scala/graviton/Hash.scala
+++ b/modules/core/src/main/scala/graviton/Hash.scala
@@ -6,7 +6,7 @@ import zio.schema.{DeriveSchema, Schema}
 final case class Hash(bytes: Chunk[Byte], algo: HashAlgorithm):
   def hex: String =
     bytes
-      .foldLeft(new StringBuilder) { (sb, b) => sb.append(f"$b%02x") }
+      .foldLeft(new StringBuilder)((sb, b) => sb.append(f"$b%02x"))
       .toString
 
 object Hash:

--- a/modules/core/src/main/scala/graviton/HashAlgorithm.scala
+++ b/modules/core/src/main/scala/graviton/HashAlgorithm.scala
@@ -6,9 +6,10 @@ import java.security.MessageDigest
 import zio.schema.{DeriveSchema, Schema}
 import zio.schema.derived
 
-/** Supported hashing algorithms for content addressed storage. Each algorithm
-  * exposes metadata about its digest and can compute hashes directly.
-  */
+/**
+ * Supported hashing algorithms for content addressed storage. Each algorithm
+ * exposes metadata about its digest and can compute hashes directly.
+ */
 sealed trait HashAlgorithm derives Schema:
   /** Canonical lowercase name of the algorithm. */
   def canonicalName: String
@@ -19,13 +20,14 @@ sealed trait HashAlgorithm derives Schema:
   /** Obtain a new `MessageDigest` instance for this algorithm. */
   protected def newDigest(): MessageDigest
 
-  /** Compute the digest for the provided data and return a lowercase hex
-    * string.
-    */
+  /**
+   * Compute the digest for the provided data and return a lowercase hex
+   * string.
+   */
   final def hash(data: Array[Byte]): String =
-    val md = newDigest()
+    val md  = newDigest()
     val dig = md.digest(data)
-    val sb = new StringBuilder(dig.length * 2)
+    val sb  = new StringBuilder(dig.length * 2)
     dig.foreach(b => sb.append(f"$b%02x"))
     sb.toString
 
@@ -35,19 +37,19 @@ sealed trait HashAlgorithm derives Schema:
 object HashAlgorithm:
 
   case object Blake3 extends HashAlgorithm:
-    val canonicalName = "blake3"
-    val digestLength = 64
+    val canonicalName                        = "blake3"
+    val digestLength                         = 64
     protected def newDigest(): MessageDigest = Blake3MessageDigest()
 
   case object SHA256 extends HashAlgorithm:
-    val canonicalName = "sha256"
-    val digestLength = 64
+    val canonicalName                        = "sha256"
+    val digestLength                         = 64
     protected def newDigest(): MessageDigest =
       MessageDigest.getInstance("SHA-256")
 
   case object SHA512 extends HashAlgorithm:
-    val canonicalName = "sha512"
-    val digestLength = 128
+    val canonicalName                        = "sha512"
+    val digestLength                         = 128
     protected def newDigest(): MessageDigest =
       MessageDigest.getInstance("SHA-512")
 
@@ -55,22 +57,22 @@ object HashAlgorithm:
 
   private val aliases: Map[String, HashAlgorithm] =
     values
-      .flatMap(a =>
-        List(a.canonicalName -> a, a.canonicalName.toUpperCase -> a)
-      )
+      .flatMap(a => List(a.canonicalName -> a, a.canonicalName.toUpperCase -> a))
       .toMap
 
-  /** Parse a hash algorithm from a string, accepting canonical and uppercase
-    * names.
-    */
+  /**
+   * Parse a hash algorithm from a string, accepting canonical and uppercase
+   * names.
+   */
   def parse(input: String): Either[String, HashAlgorithm] =
     aliases.get(input).toRight(s"Unknown hash algorithm: $input")
 
   given Schema[HashAlgorithm] = DeriveSchema.gen[HashAlgorithm]
 
-/** MessageDigest wrapper providing a `MessageDigest`-compatible interface for
-  * the Blake3 implementation which uses its own API.
-  */
+/**
+ * MessageDigest wrapper providing a `MessageDigest`-compatible interface for
+ * the Blake3 implementation which uses its own API.
+ */
 private final class Blake3MessageDigest extends MessageDigest("BLAKE3"):
   import io.github.rctcwyvrn.blake3.Blake3
 

--- a/modules/core/src/main/scala/graviton/InsertChunkResult.scala
+++ b/modules/core/src/main/scala/graviton/InsertChunkResult.scala
@@ -1,7 +1,7 @@
 package graviton
 
 final case class InsertChunkResult(
-    id: BinaryId,
-    size: Long,
-    deduplicated: Boolean
+  id: BinaryId,
+  size: Long,
+  deduplicated: Boolean,
 )

--- a/modules/core/src/main/scala/graviton/InvertibleArrow.scala
+++ b/modules/core/src/main/scala/graviton/InvertibleArrow.scala
@@ -2,27 +2,28 @@ package graviton
 
 import zio.Chunk
 
-/** A purely data-based, invertible arrow. It captures primitive steps and their
-  * arguments without embedding executable functions, allowing the structure to
-  * be inspected, serialised and reversed.
-  */
+/**
+ * A purely data-based, invertible arrow. It captures primitive steps and their
+ * arguments without embedding executable functions, allowing the structure to
+ * be inspected, serialised and reversed.
+ */
 sealed trait InvertibleArrow[A, B]:
   self =>
   import InvertibleArrow.*
 
   transparent inline def >>>[C](
-      that: InvertibleArrow[B, C]
+    that: InvertibleArrow[B, C]
   ): InvertibleArrow[A, C] =
     Compose(self, that)
 
   /** Reverse this arrow. */
   def invert: InvertibleArrow[B, A] =
     this match
-      case Id() => Id().asInstanceOf[InvertibleArrow[B, A]]
+      case Id()               => Id().asInstanceOf[InvertibleArrow[B, A]]
       case p: Primitive[?, ?] =>
         Primitive[B, A](p.inverseLabel, p.args, p.label)
           .asInstanceOf[InvertibleArrow[B, A]]
-      case Compose(f, g) =>
+      case Compose(f, g)      =>
         (g.invert >>> f.invert).asInstanceOf[InvertibleArrow[B, A]]
 
   /** List the primitive steps in order. */
@@ -39,21 +40,21 @@ object InvertibleArrow:
 
   /** A primitive step identified purely by metadata. */
   final case class Primitive[A, B](
-      label: String,
-      args: Chunk[(String, Any)] = Chunk.empty,
-      inverseLabel: String
+    label: String,
+    args: Chunk[(String, Any)] = Chunk.empty,
+    inverseLabel: String,
   ) extends InvertibleArrow[A, B]
 
   /** Composition of two arrows. */
   final case class Compose[A, B, C](
-      first: InvertibleArrow[A, B],
-      second: InvertibleArrow[B, C]
+    first: InvertibleArrow[A, B],
+    second: InvertibleArrow[B, C],
   ) extends InvertibleArrow[A, C]
 
   /** Lift a primitive step by providing its label and inverse label. */
   def lift[A, B](
-      label: String,
-      inverse: String,
-      args: (String, Any)*
+    label: String,
+    inverse: String,
+    args: (String, Any)*
   ): InvertibleArrow[A, B] =
     Primitive(label, Chunk.fromIterable(args), inverse)

--- a/modules/core/src/main/scala/graviton/Scan.scala
+++ b/modules/core/src/main/scala/graviton/Scan.scala
@@ -9,11 +9,12 @@ import zio.prelude.fx.ZPure
 import io.github.iltotore.iron.*
 import io.github.iltotore.iron.constraint.all.*
 
-/** A stateful stream transformer whose state is represented as a Tuple.
-  * Stateless scans use `EmptyTuple` and therefore do not alter the state type
-  * when composed. Composition operators are `transparent inline` to encourage
-  * compile-time optimisation and eliminate intermediate allocations.
-  */
+/**
+ * A stateful stream transformer whose state is represented as a Tuple.
+ * Stateless scans use `EmptyTuple` and therefore do not alter the state type
+ * when composed. Composition operators are `transparent inline` to encourage
+ * compile-time optimisation and eliminate intermediate allocations.
+ */
 sealed trait Scan[-I, +O]:
   type State <: Tuple
 
@@ -31,7 +32,7 @@ object Scan:
       I
     ], Any, Nothing, Take[Nothing, O], Any] =
       def loop(
-          state: S
+        state: S
       ): ZChannel[Any, Nothing, Chunk[I], Any, Nothing, Take[Nothing, O], Any] =
         ZChannel.readWith(
           in =>
@@ -45,7 +46,7 @@ object Scan:
           _ =>
             ZChannel.write(Take.chunk(self.done(state))) *>
               ZChannel.write(Take.end) *>
-              ZChannel.unit
+              ZChannel.unit,
         )
       loop(self.initial)
 
@@ -55,7 +56,7 @@ object Scan:
           _.fold(
             Chunk.empty[O],
             cause => throw cause.squash,
-            chunk => chunk
+            chunk => chunk,
           )
         )
       )
@@ -70,14 +71,14 @@ object Scan:
       )(s => self.done(s).map(f))
 
     transparent inline def contramap[I2](
-        inline f: I2 => I
+      inline f: I2 => I
     ): Scan.Aux[I2, O, S] =
       statefulTuple(self.initial)((s: S, i2: I2) => self.step(s, f(i2): I))(
         self.done
       )
 
     transparent inline def dimap[I2, O2](inline g: I2 => I)(
-        inline f: O => O2
+      inline f: O => O2
     ): Scan.Aux[I2, O2, S] =
       statefulTuple(self.initial)((s: S, i2: I2) =>
         val (s2, o) = self.step(s, g(i2): I)
@@ -85,15 +86,15 @@ object Scan:
       )(s => self.done(s).map(f))
 
     transparent inline def andThen[O2, S2 <: Tuple](
-        inline that: Scan.Aux[O, O2, S2]
+      inline that: Scan.Aux[O, O2, S2]
     ): Scan.Aux[I, O2, Tuple.Concat[S, S2]] =
       val sizeA = self.initial.productArity
       statefulTuple(self.initial ++ that.initial)((st: Tuple, i: I) =>
-        val s1 = st.take(sizeA).asInstanceOf[S]
-        val s2 = st.drop(sizeA).asInstanceOf[S2]
+        val s1        = st.take(sizeA).asInstanceOf[S]
+        val s2        = st.drop(sizeA).asInstanceOf[S2]
         val (s1b, o1) = self.step(s1, i)
-        var s2b = s2
-        val builder = ChunkBuilder.make[O2]()
+        var s2b       = s2
+        val builder   = ChunkBuilder.make[O2]()
         o1.foreach { o =>
           val (s2n, o2) = that.step(s2b, o)
           s2b = s2n
@@ -101,10 +102,10 @@ object Scan:
         }
         ((s1b ++ s2b).asInstanceOf[Tuple.Concat[S, S2]], builder.result())
       ) { (st: Tuple) =>
-        val s1 = st.take(sizeA).asInstanceOf[S]
-        val s2 = st.drop(sizeA).asInstanceOf[S2]
+        val s1      = st.take(sizeA).asInstanceOf[S]
+        val s2      = st.drop(sizeA).asInstanceOf[S2]
         val interim = self.done(s1)
-        var s2b = s2
+        var s2b     = s2
         val builder = ChunkBuilder.make[O2]()
         interim.foreach { o =>
           val (s2n, o2) = that.step(s2b, o)
@@ -115,17 +116,17 @@ object Scan:
       }
 
     transparent inline def flatMap[O2, S2 <: Tuple](
-        inline that: Scan.Aux[O, O2, S2]
+      inline that: Scan.Aux[O, O2, S2]
     ): Scan.Aux[I, O2, Tuple.Concat[S, S2]] =
       andThen(that)
 
     transparent inline def zip[O2, S2 <: Tuple](
-        inline that: Scan.Aux[I, O2, S2]
+      inline that: Scan.Aux[I, O2, S2]
     ): Scan.Aux[I, (O, O2), Tuple.Concat[S, S2]] =
       val sizeA = self.initial.productArity
       statefulTuple(self.initial ++ that.initial)((st: Tuple, i: I) =>
-        val s1 = st.take(sizeA).asInstanceOf[S]
-        val s2 = st.drop(sizeA).asInstanceOf[S2]
+        val s1        = st.take(sizeA).asInstanceOf[S]
+        val s2        = st.drop(sizeA).asInstanceOf[S2]
         val (s1b, o1) = self.step(s1, i)
         val (s2b, o2) = that.step(s2, i)
         ((s1b ++ s2b).asInstanceOf[Tuple.Concat[S, S2]], o1.zip(o2))
@@ -136,11 +137,11 @@ object Scan:
       }
 
     transparent inline def runAll(
-        inputs: Iterable[I]
+      inputs: Iterable[I]
     ): (S, Chunk[O]) =
-      var state = self.initial
+      var state   = self.initial
       val builder = ChunkBuilder.make[O]()
-      val it = inputs.iterator
+      val it      = inputs.iterator
       while it.hasNext do
         val (s, out) = self.step(state, it.next())
         state = s
@@ -149,12 +150,12 @@ object Scan:
       (state, builder.result())
 
     transparent inline def runZPure(
-        inputs: Iterable[I]
+      inputs: Iterable[I]
     ): ZPure[Nothing, S, S, Any, Nothing, Chunk[O]] =
       ZPure.modify { (st: S) =>
-        var state = st
+        var state   = st
         val builder = ChunkBuilder.make[O]()
-        val it = inputs.iterator
+        val it      = inputs.iterator
         while it.hasNext do
           val (s, out) = self.step(state, it.next())
           state = s
@@ -175,7 +176,7 @@ object Scan:
 
     def stepSingle(state: EmptyTuple, in: I) =
       var res: Any = in
-      var i = 0
+      var i        = 0
       while i < fs.length do
         res = fs(i)(res)
         i += 1
@@ -191,11 +192,11 @@ object Scan:
     new StatelessChain[I, O](Chunk.single(f.asInstanceOf[Any => Any]))
 
   def stateless[I, O](
-      f: I => Chunk[O]
+    f: I => Chunk[O]
   ): Stateless[I, O] =
     new Stateless[I, O]:
       def step(state: EmptyTuple, in: I) = (state, f(in))
-      def done(state: EmptyTuple) = Chunk.empty
+      def done(state: EmptyTuple)        = Chunk.empty
 
   // ---------------------- Stateful helpers ----------------------
 
@@ -204,32 +205,32 @@ object Scan:
     val initial: S
 
   def stateful[I, O, S](init: S)(
-      stepFn: (S, I) => (S, Chunk[O])
+    stepFn: (S, I) => (S, Chunk[O])
   )(doneFn: S => Chunk[O]): Stateful[I, O, S *: EmptyTuple] =
     new Stateful[I, O, S *: EmptyTuple]:
-      val initial = init *: EmptyTuple
+      val initial                             = init *: EmptyTuple
       def step(state: S *: EmptyTuple, in: I) =
         val (s, o) = stepFn(state.head, in)
         (s *: EmptyTuple, o)
-      def done(state: S *: EmptyTuple) = doneFn(state.head)
+      def done(state: S *: EmptyTuple)        = doneFn(state.head)
 
   def statefulTuple[I, O, S <: Tuple](init: S)(
-      stepFn: (S, I) => (S, Chunk[O])
+    stepFn: (S, I) => (S, Chunk[O])
   )(doneFn: S => Chunk[O]): Stateful[I, O, S] =
     new Stateful[I, O, S]:
-      val initial = init
+      val initial               = init
       def step(state: S, in: I) = stepFn(state, in)
-      def done(state: S) = doneFn(state)
+      def done(state: S)        = doneFn(state)
 
   transparent inline def apply[I, O, S](init: S)(
-      inline stepFn: (S, I) => (S, Chunk[O])
+    inline stepFn: (S, I) => (S, Chunk[O])
   )(inline doneFn: S => Chunk[O]): Stateful[I, O, S *: EmptyTuple] =
     stateful(init)(stepFn)(doneFn)
 
   // identity
   private object Identity extends Stateless[Any, Any]:
     def step(state: EmptyTuple, in: Any) = (state, Chunk.single(in))
-    def done(state: EmptyTuple) = Chunk.empty
+    def done(state: EmptyTuple)          = Chunk.empty
 
   transparent inline def identity[I]: Aux[I, I, EmptyTuple] =
     Identity.asInstanceOf[Aux[I, I, EmptyTuple]]
@@ -241,9 +242,7 @@ object Scan:
 
   /** Counts the number of elements in the incoming stream. */
   val count: Aux[Any, Long, Long *: EmptyTuple] =
-    stateful[Any, Long, Long](0L)((s, _) => (s + 1L, Chunk.empty))(s =>
-      Chunk.single(s)
-    )
+    stateful[Any, Long, Long](0L)((s, _) => (s + 1L, Chunk.empty))(s => Chunk.single(s))
 
   /** Computes a hash of all bytes using the provided algorithm. */
   def hash(algo: HashAlgorithm): Aux[Byte, Hash, AnyRef *: EmptyTuple] =
@@ -252,28 +251,27 @@ object Scan:
         val md = java.security.MessageDigest.getInstance(algo match
           case HashAlgorithm.SHA256 => "SHA-256"
           case HashAlgorithm.SHA512 => "SHA-512"
-          case _                    => "SHA-256"
-        )
-        stateful[Byte, Hash, java.security.MessageDigest](md)((m, b) => {
+          case _                    => "SHA-256")
+        stateful[Byte, Hash, java.security.MessageDigest](md) { (m, b) =>
           m.update(b); (m, Chunk.empty)
-        })(m =>
+        }(m =>
           Chunk.single(
             Hash(
               Chunk.fromArray(m.digest()).assume[MinLength[16] & MaxLength[64]],
-              algo
+              algo,
             )
           )
         )
           .asInstanceOf[Aux[Byte, Hash, AnyRef *: EmptyTuple]]
-      case HashAlgorithm.Blake3 =>
+      case HashAlgorithm.Blake3                        =>
         val bl = io.github.rctcwyvrn.blake3.Blake3.newInstance()
-        stateful[Byte, Hash, io.github.rctcwyvrn.blake3.Blake3](bl)((h, b) => {
+        stateful[Byte, Hash, io.github.rctcwyvrn.blake3.Blake3](bl) { (h, b) =>
           h.update(Array(b)); (h, Chunk.empty)
-        })(h =>
+        }(h =>
           Chunk.single(
             Hash(
               Chunk.fromArray(h.digest()).assume[MinLength[16] & MaxLength[64]],
-              algo
+              algo,
             )
           )
         )
@@ -281,7 +279,7 @@ object Scan:
 
   /** Convenience scan that produces both hash and count in one pass. */
   def hashAndCount(
-      algo: HashAlgorithm
+    algo: HashAlgorithm
   ): Aux[Byte, (Hash, Long), (AnyRef, Long)] =
     val initHasher: AnyRef = algo match
       case HashAlgorithm.SHA256 =>
@@ -298,8 +296,8 @@ object Scan:
       ((h, c + 1L), Chunk.empty)
     } { (state) =>
       val (h, c) = state
-      val dig = h match
-        case md: java.security.MessageDigest => Chunk.fromArray(md.digest())
+      val dig    = h match
+        case md: java.security.MessageDigest       => Chunk.fromArray(md.digest())
         case bl: io.github.rctcwyvrn.blake3.Blake3 =>
           Chunk.fromArray(bl.digest())
       val digRef = dig.assume[MinLength[16] & MaxLength[64]]
@@ -311,14 +309,13 @@ object Scan:
   final case class ChunkState[I](buffer: Chunk[I], cost: Int)
 
   def chunkBy[I](
-      costFn: I => Int,
-      threshold: Int
+    costFn: I => Int,
+    threshold: Int,
   ): Aux[I, Chunk[I], ChunkState[I] *: EmptyTuple] =
     stateful(ChunkState(Chunk.empty[I], 0)) { (st: ChunkState[I], i: I) =>
-      val buf1 = st.buffer :+ i
+      val buf1  = st.buffer :+ i
       val cost1 = st.cost + costFn(i)
-      if cost1 >= threshold then
-        (ChunkState(Chunk.empty, 0), Chunk.single(buf1))
+      if cost1 >= threshold then (ChunkState(Chunk.empty, 0), Chunk.single(buf1))
       else (ChunkState(buf1, cost1), Chunk.empty)
     } { st =>
       if st.buffer.isEmpty then Chunk.empty else Chunk.single(st.buffer)

--- a/modules/core/src/main/scala/graviton/chunking/Chunker.scala
+++ b/modules/core/src/main/scala/graviton/chunking/Chunker.scala
@@ -14,7 +14,7 @@ object Chunker:
   final case class Bounds(min: Int, avg: Int, max: Int):
     require(
       min > 0 && avg >= min && max >= avg,
-      "Bounds(min <= avg <= max) violated"
+      "Bounds(min <= avg <= max) violated",
     )
 
   /** Strategy tag for telemetry & selection. */
@@ -34,9 +34,9 @@ object Chunker:
 
   /** Configuration for smart selection. */
   final case class SmartConfig(
-      default: Strategy,
-      rules: List[SmartRule],
-      smallFileFixed: Int = 1 << 18
+    default: Strategy,
+    rules: List[SmartRule],
+    smallFileFixed: Int = 1 << 18,
   )
 
   /** Select a [[Chunker]] based on the provided [[SmartConfig]] and hints. */
@@ -56,8 +56,8 @@ object Chunker:
 
   /** Build a [[Chunker]] from a strategy. */
   def fromStrategy(s: Strategy): Chunker = s match
-    case Strategy.Fixed(sz) => FixedChunker(sz)
-    case Strategy.FastCDC(b, n, w) =>
+    case Strategy.Fixed(sz)                 => FixedChunker(sz)
+    case Strategy.FastCDC(b, n, w)          =>
       FastCDCChunker(FastCDCChunker.Config(b, n, w))
     case Strategy.Pdf                       => PdfChunker
     case Strategy.Smart(default, overrides) =>
@@ -66,5 +66,5 @@ object Chunker:
         SmartConfig(default, overrides),
         new SmartHints:
           val contentType: Option[String] = None
-          val contentLength: Option[Long] = None
+          val contentLength: Option[Long] = None,
       )

--- a/modules/core/src/main/scala/graviton/chunking/FastCDCChunker.scala
+++ b/modules/core/src/main/scala/graviton/chunking/FastCDCChunker.scala
@@ -7,15 +7,15 @@ object FastCDCChunker:
   import Chunker.Bounds
 
   final case class Config(
-      bounds: Bounds,
-      normalization: Int = 2,
-      window: Int = 64
+    bounds: Bounds,
+    normalization: Int = 2,
+    window: Int = 64,
   )
 
   private val gearTable: Array[Int] =
-    val arr = new Array[Int](256)
+    val arr  = new Array[Int](256)
     var seed = 0x12345678
-    var i = 0
+    var i    = 0
     while i < 256 do
       seed = (seed * 1664525 + 1013904223) & 0xffffffff
       arr(i) = seed
@@ -24,7 +24,7 @@ object FastCDCChunker:
 
   def apply(cfg: Config): Chunker =
     new Chunker:
-      val name =
+      val name                                                   =
         s"fastcdc(min=${cfg.bounds.min},avg=${cfg.bounds.avg},max=${cfg.bounds.max})"
       val pipeline: ZPipeline[Any, Throwable, Byte, Chunk[Byte]] =
         ZPipeline.fromChannel:
@@ -34,20 +34,20 @@ object FastCDCChunker:
             ZChannel.readWith(
               (in: Chunk[Byte]) => loop(buf ++ in),
               (err: Throwable) => ZChannel.fail(err),
-              (_: Any) => ZChannel.write(split(buf, cfg))
+              (_: Any) => ZChannel.write(split(buf, cfg)),
             )
           loop(Chunk.empty)
 
   private def split(bytes: Chunk[Byte], cfg: Config): Chunk[Chunk[Byte]] =
-    val bits = math.round(math.log(cfg.bounds.avg.toDouble) / math.log(2)).toInt
-    val maskS = (1 << (bits + 1)) - 1
-    val maskL = (1 << (bits - 1)) - 1
+    val bits       = math.round(math.log(cfg.bounds.avg.toDouble) / math.log(2)).toInt
+    val maskS      = (1 << (bits + 1)) - 1
+    val maskL      = (1 << (bits - 1)) - 1
     val centerSize = cfg.bounds.avg - math.min(
       cfg.bounds.avg,
-      cfg.bounds.min + (cfg.bounds.min + 1) / 2
+      cfg.bounds.min + (cfg.bounds.min + 1) / 2,
     )
-    val chunks = scala.collection.mutable.ListBuffer.empty[Chunk[Byte]]
-    var offset = 0
+    val chunks     = scala.collection.mutable.ListBuffer.empty[Chunk[Byte]]
+    var offset     = 0
     while offset < bytes.length do
       val remaining = bytes.length - offset
       if remaining <= cfg.bounds.min then
@@ -55,11 +55,11 @@ object FastCDCChunker:
         offset = bytes.length
       else
         val realSize = math.min(remaining, cfg.bounds.max)
-        val bound1 = offset + math.min(centerSize, realSize)
-        val bound2 = offset + realSize
-        var hash = 0
-        var pos = offset + cfg.bounds.min
-        var cut = 0
+        val bound1   = offset + math.min(centerSize, realSize)
+        val bound2   = offset + realSize
+        var hash     = 0
+        var pos      = offset + cfg.bounds.min
+        var cut      = 0
         while pos < bound1 && cut == 0 do
           val b = bytes(pos) & 0xff
           hash = (hash >>> 1) + gearTable(b)

--- a/modules/core/src/main/scala/graviton/chunking/FixedChunker.scala
+++ b/modules/core/src/main/scala/graviton/chunking/FixedChunker.scala
@@ -7,7 +7,7 @@ import zio.stream.*
 object FixedChunker:
   def apply(size: Int): Chunker =
     new Chunker:
-      val name = s"fixed($size)"
+      val name                                                   = s"fixed($size)"
       val pipeline: ZPipeline[Any, Throwable, Byte, Chunk[Byte]] =
         ZPipeline.fromChannel:
           def splitAll(acc: Chunk[Byte]): (Chunk[Chunk[Byte]], Chunk[Byte]) =
@@ -30,6 +30,6 @@ object FixedChunker:
               (err: Throwable) => ZChannel.fail(err),
               (_: Any) =>
                 if buf.isEmpty then ZChannel.unit
-                else ZChannel.write(Chunk(buf))
+                else ZChannel.write(Chunk(buf)),
             )
           loop(Chunk.empty)

--- a/modules/core/src/main/scala/graviton/collections/Range.scala
+++ b/modules/core/src/main/scala/graviton/collections/Range.scala
@@ -6,10 +6,7 @@ import scala.math.Ordering
 final case class Range[A](start: A, end: A):
 
   /** Subtract a range from this range. Result may be 0, 1 or 2 ranges. */
-  def -(range: Range[A])(using
-      discrete: Discrete[A],
-      ord: Ordering[A]
-  ): Option[(Range[A], Option[Range[A]])] =
+  def -(range: Range[A])(using discrete: Discrete[A], ord: Ordering[A]): Option[(Range[A], Option[Range[A]])] =
     if ord.lteq(range.start, start) then
       if ord.lt(range.end, start) then Some((this, None))
       else if ord.gteq(range.end, end) then None
@@ -18,19 +15,14 @@ final case class Range[A](start: A, end: A):
     else
       val r1 = Range(start, discrete.pred(range.start))
       val r2 =
-        if ord.lt(range.end, end) then
-          Some(Range(discrete.succ(range.end), end))
+        if ord.lt(range.end, end) then Some(Range(discrete.succ(range.end), end))
         else None
       Some((r1, r2))
 
-  def +(other: Range[A])(using
-      ord: Ordering[A],
-      discrete: Discrete[A]
-  ): (Range[A], Option[Range[A]]) =
+  def +(other: Range[A])(using ord: Ordering[A], discrete: Discrete[A]): (Range[A], Option[Range[A]]) =
     val (l, r) =
       if ord.lt(this.start, other.start) then (this, other) else (other, this)
-    if ord.gteq(l.end, r.start) || discrete.adj(l.end, r.start) then
-      (Range(l.start, ord.max(l.end, r.end)), None)
+    if ord.gteq(l.end, r.start) || discrete.adj(l.end, r.start) then (Range(l.start, ord.max(l.end, r.end)), None)
     else (Range(l.start, l.end), Some(Range(r.start, r.end)))
 
   def &(other: Range[A])(using ord: Ordering[A]): Option[Range[A]] =
@@ -63,7 +55,7 @@ final case class Range[A](start: A, end: A):
   def reverse: Range[A] = Range(end, start)
 
   def foreach(
-      f: A => Unit
+    f: A => Unit
   )(using discrete: Discrete[A], ord: Ordering[A]): Unit =
     var i = start
     while ord.lt(i, end) do
@@ -73,19 +65,10 @@ final case class Range[A](start: A, end: A):
 
   def map[B](f: A => B): Range[B] = Range(f(start), f(end))
 
-  def foldLeft[B](s: B, f: (B, A) => B)(using
-      discrete: Discrete[A],
-      ord: Ordering[A]
-  ): B =
+  def foldLeft[B](s: B, f: (B, A) => B)(using discrete: Discrete[A], ord: Ordering[A]): B =
     var b = s
     foreach { a => b = f(b, a) }
     b
 
-  def foldRight[B](s: B, f: (A, B) => B)(using
-      discrete: Discrete[A],
-      ord: Ordering[A]
-  ): B =
-    reverse.foldLeft(s, (b: B, a: A) => f(a, b))(using
-      discrete.inverse,
-      ord.reverse
-    )
+  def foldRight[B](s: B, f: (A, B) => B)(using discrete: Discrete[A], ord: Ordering[A]): B =
+    reverse.foldLeft(s, (b: B, a: A) => f(a, b))(using discrete.inverse, ord.reverse)

--- a/modules/core/src/main/scala/graviton/collections/syntax/RangeSyntax.scala
+++ b/modules/core/src/main/scala/graviton/collections/syntax/RangeSyntax.scala
@@ -4,6 +4,6 @@ import graviton.collections.{Range, Discrete}
 
 trait RangeSyntax:
   extension [A](a: A)
-    def toIncl(to: A): Range[A] = Range(a, to)
+    def toIncl(to: A): Range[A]                    = Range(a, to)
     def toExcl(to: A)(using Discrete[A]): Range[A] =
       Range(a, summon[Discrete[A]].pred(to))

--- a/modules/core/src/main/scala/graviton/core/BinaryAttributeKey.scala
+++ b/modules/core/src/main/scala/graviton/core/BinaryAttributeKey.scala
@@ -4,9 +4,7 @@ import zio.schema.*
 import java.util.UUID
 import java.time.Instant
 
-final case class BinaryAttributeKey[+A](id: String)(using
-    val schema: Schema[? <: A]
-)
+final case class BinaryAttributeKey[+A](id: String)(using val schema: Schema[? <: A])
 object BinaryAttributeKey:
 
   val size: BinaryAttributeKey[Long] =

--- a/modules/core/src/main/scala/graviton/core/BinaryAttributes.scala
+++ b/modules/core/src/main/scala/graviton/core/BinaryAttributes.scala
@@ -16,60 +16,48 @@ private object DynamicAttr:
   def from[A](attr: BinaryAttribute[A])(using Schema[A]): DynamicAttr =
     DynamicAttr(
       DynamicValue.fromSchemaAndValue(Schema[A], attr.value),
-      attr.source
+      attr.source,
     )
 
 final case class BinaryAttributes private (
-    advertised: ListMap[BinaryAttributeKey[?], DynamicAttr],
-    confirmed: ListMap[BinaryAttributeKey[?], DynamicAttr]
+  advertised: ListMap[BinaryAttributeKey[?], DynamicAttr],
+  confirmed: ListMap[BinaryAttributeKey[?], DynamicAttr],
 ):
-  def getAdvertised[A](k: BinaryAttributeKey[A])(using
-      Schema[A]
-  ): Option[BinaryAttribute[A]] =
+  def getAdvertised[A](k: BinaryAttributeKey[A])(using Schema[A]): Option[BinaryAttribute[A]] =
     advertised.get(k).flatMap(_.to[A])
 
-  def getConfirmed[A](k: BinaryAttributeKey[A])(using
-      Schema[A]
-  ): Option[BinaryAttribute[A]] =
+  def getConfirmed[A](k: BinaryAttributeKey[A])(using Schema[A]): Option[BinaryAttribute[A]] =
     confirmed.get(k).flatMap(_.to[A])
 
-  def putAdvertised[A](k: BinaryAttributeKey[A], attr: BinaryAttribute[A])(using
-      Schema[A]
-  ): BinaryAttributes =
+  def putAdvertised[A](k: BinaryAttributeKey[A], attr: BinaryAttribute[A])(using Schema[A]): BinaryAttributes =
     copy(advertised = advertised.updated(k, DynamicAttr.from(attr)))
 
-  def putConfirmed[A](k: BinaryAttributeKey[A], attr: BinaryAttribute[A])(using
-      Schema[A]
-  ): BinaryAttributes =
+  def putConfirmed[A](k: BinaryAttributeKey[A], attr: BinaryAttribute[A])(using Schema[A]): BinaryAttributes =
     copy(confirmed = confirmed.updated(k, DynamicAttr.from(attr)))
 
   def ++(other: BinaryAttributes): BinaryAttributes =
     BinaryAttributes(
       advertised ++ other.advertised,
-      confirmed ++ other.confirmed
+      confirmed ++ other.confirmed,
     )
 
 object BinaryAttributes:
   val empty: BinaryAttributes = BinaryAttributes(ListMap.empty, ListMap.empty)
 
-  def advertised[A](k: BinaryAttributeKey[A], value: A, source: String)(using
-      Schema[A]
-  ): BinaryAttributes =
+  def advertised[A](k: BinaryAttributeKey[A], value: A, source: String)(using Schema[A]): BinaryAttributes =
     empty.putAdvertised(k, BinaryAttribute(value, source))
 
-  def confirmed[A](k: BinaryAttributeKey[A], value: A, source: String)(using
-      Schema[A]
-  ): BinaryAttributes =
+  def confirmed[A](k: BinaryAttributeKey[A], value: A, source: String)(using Schema[A]): BinaryAttributes =
     empty.putConfirmed(k, BinaryAttribute(value, source))
 
-  private val FilenamePattern = "^[^\\/\\r\\n]+$".r
+  private val FilenamePattern  = "^[^\\/\\r\\n]+$".r
   private val MediaTypePattern = "^[\\w.+-]+/[\\w.+-]+$".r
 
   def validate(attrs: BinaryAttributes): IO[GravitonError, Unit] =
     def validateAll(
-        values: List[String],
-        pattern: scala.util.matching.Regex,
-        msg: String
+      values: List[String],
+      pattern: scala.util.matching.Regex,
+      msg: String,
     ): IO[GravitonError, Unit] =
       ZIO.foreachDiscard(values) { v =>
         if pattern.pattern.matcher(v).matches() then ZIO.unit
@@ -78,12 +66,12 @@ object BinaryAttributes:
 
     val filenames = List(
       attrs.getAdvertised(BinaryAttributeKey.filename).map(_.value),
-      attrs.getConfirmed(BinaryAttributeKey.filename).map(_.value)
+      attrs.getConfirmed(BinaryAttributeKey.filename).map(_.value),
     ).flatten
 
     val mediaTypes = List(
       attrs.getAdvertised(BinaryAttributeKey.contentType).map(_.value),
-      attrs.getConfirmed(BinaryAttributeKey.contentType).map(_.value)
+      attrs.getConfirmed(BinaryAttributeKey.contentType).map(_.value),
     ).flatten
 
     for

--- a/modules/core/src/main/scala/graviton/core/BinaryKey.scala
+++ b/modules/core/src/main/scala/graviton/core/BinaryKey.scala
@@ -12,18 +12,19 @@ import zio.schema.{DeriveSchema, Schema, derived}
 import graviton.Hash
 import zio.schema.validation.Validation
 
-/** Identifier for binary content. Keys can either be content addressed
-  * (`CasKey`) or writable user supplied keys such as randomly generated UUIDs
-  * or static strings.
-  */
+/**
+ * Identifier for binary content. Keys can either be content addressed
+ * (`CasKey`) or writable user supplied keys such as randomly generated UUIDs
+ * or static strings.
+ */
 sealed trait BinaryKey derives Schema:
   import BinaryKey.*
 
   /** Render this key as a URI-like string. */
   def renderKey: String = this match
-    case CasKey(hash)        => s"cas:${hash.algo.canonicalName}/${hash.hex}"
-    case WritableKey.Rnd(id) => s"uuid:${id.toString}"
-    case WritableKey.Static(name) => s"user:$name"
+    case CasKey(hash)                   => s"cas:${hash.algo.canonicalName}/${hash.hex}"
+    case WritableKey.Rnd(id)            => s"uuid:${id.toString}"
+    case WritableKey.Static(name)       => s"user:$name"
     case WritableKey.Scoped(scope, key) =>
       val encoded =
         val joined = scope
@@ -45,11 +46,11 @@ object BinaryKey:
   sealed trait WritableKey extends BinaryKey
 
   object WritableKey:
-    final case class Rnd(id: UUID) extends WritableKey
+    final case class Rnd(id: UUID)       extends WritableKey
     final case class Static(key: String) extends WritableKey
     final case class Scoped(
-        scope: ListMap[String, NonEmptyChunk[String]],
-        key: String
+      scope: ListMap[String, NonEmptyChunk[String]],
+      key: String,
     ) extends WritableKey
 
     def random(id: UUID): WritableKey = Rnd(id)
@@ -57,24 +58,27 @@ object BinaryKey:
     def randomF(using Trace): UIO[WritableKey] =
       zio.Random.nextUUID.map(Rnd.apply)
 
-
     private def validateKey(key: String): Either[String, String] =
-      Option(key).toRight("WritableKey.static: key cannot be null")
-      .flatMap(key => Option(key).filter(_.trim.nonEmpty).toRight("WritableKey.static: key must be non-empty"))
+      Option(key)
+        .toRight("WritableKey.static: key cannot be null")
+        .flatMap(key => Option(key).filter(_.trim.nonEmpty).toRight("WritableKey.static: key must be non-empty"))
 
     def static(key: String): Either[String, WritableKey] =
       validateKey(key).map(Static(_))
 
     def scoped(
-        scope: ListMap[String, NonEmptyChunk[String]],
-        key: String
+      scope: ListMap[String, NonEmptyChunk[String]],
+      key: String,
     ): zio.prelude.Validation[String, WritableKey] =
-      zio.prelude.Validation.validate(
-        zio.prelude.Validation.fromPredicate(scope)(_.nonEmpty)
-        .mapError(_ => "WritableKey.scoped: scope must be non-empty"),
-        zio.prelude.Validation.fromEither(validateKey(key))
-      ).map { case (scope, value) => Scoped(scope.map((k, v) => (k.trim, v)), value.trim) }
-      
+      zio.prelude.Validation
+        .validate(
+          zio.prelude.Validation
+            .fromPredicate(scope)(_.nonEmpty)
+            .mapError(_ => "WritableKey.scoped: scope must be non-empty"),
+          zio.prelude.Validation.fromEither(validateKey(key)),
+        )
+        .map { case (scope, value) => Scoped(scope.map((k, v) => (k.trim, v)), value.trim) }
+
   export WritableKey.{Rnd, Scoped, Static}
 
   given Schema[BinaryKey] = DeriveSchema.gen[BinaryKey]

--- a/modules/core/src/main/scala/graviton/core/BinaryKeyMatcher.scala
+++ b/modules/core/src/main/scala/graviton/core/BinaryKeyMatcher.scala
@@ -9,20 +9,16 @@ import graviton.HashAlgorithm
 
 sealed trait BinaryKeyMatcher derives Schema
 object BinaryKeyMatcher:
-    case object AnyKey extends BinaryKeyMatcher
-    final case class ByAlg(alg: HashAlgorithm) extends BinaryKeyMatcher
-    final case class ByCasPrefix(prefix: Chunk[Byte]) extends BinaryKeyMatcher
-    final case class ByScope(prefix: ListMap[String, Option[String]])
-        extends BinaryKeyMatcher
-    final case class And(left: BinaryKeyMatcher, right: BinaryKeyMatcher)
-        extends BinaryKeyMatcher
-    final case class Or(left: BinaryKeyMatcher, right: BinaryKeyMatcher)
-        extends BinaryKeyMatcher
-    final case class Not(inner: BinaryKeyMatcher) extends BinaryKeyMatcher
+  case object AnyKey                                                    extends BinaryKeyMatcher
+  final case class ByAlg(alg: HashAlgorithm)                            extends BinaryKeyMatcher
+  final case class ByCasPrefix(prefix: Chunk[Byte])                     extends BinaryKeyMatcher
+  final case class ByScope(prefix: ListMap[String, Option[String]])     extends BinaryKeyMatcher
+  final case class And(left: BinaryKeyMatcher, right: BinaryKeyMatcher) extends BinaryKeyMatcher
+  final case class Or(left: BinaryKeyMatcher, right: BinaryKeyMatcher)  extends BinaryKeyMatcher
+  final case class Not(inner: BinaryKeyMatcher)                         extends BinaryKeyMatcher
 
-    extension (m: BinaryKeyMatcher)
-        def &&(that: BinaryKeyMatcher): BinaryKeyMatcher = And(m, that)
-        def ||(that: BinaryKeyMatcher): BinaryKeyMatcher = Or(m, that)
-        def unary_! : BinaryKeyMatcher = Not(m)
-    end extension
-
+  extension (m: BinaryKeyMatcher)
+    def &&(that: BinaryKeyMatcher): BinaryKeyMatcher = And(m, that)
+    def ||(that: BinaryKeyMatcher): BinaryKeyMatcher = Or(m, that)
+    def unary_! : BinaryKeyMatcher                   = Not(m)
+  end extension

--- a/modules/core/src/main/scala/graviton/core/BlobStore.scala
+++ b/modules/core/src/main/scala/graviton/core/BlobStore.scala
@@ -5,11 +5,11 @@ import zio.stream.*
 
 trait BlobStore extends BlockStore:
   def insertWith(
-      key: BinaryKey.WritableKey
+    key: BinaryKey.WritableKey
   ): ZSink[Any, Throwable, Byte, Byte, Boolean]
   def findBinary(key: BinaryKey): IO[Throwable, Option[Bytes]]
   def copy(from: BinaryKey, to: BinaryKey.WritableKey): IO[Throwable, Unit]
   override def delete(key: BinaryKey): IO[Throwable, Boolean]
   def writeWithAttrs(
-      provided: BinaryAttributes
+    provided: BinaryAttributes
   ): ZSink[Any, Throwable, Byte, Byte, (BinaryKey.CasKey, BinaryAttributes)]

--- a/modules/core/src/main/scala/graviton/core/BlockStore.scala
+++ b/modules/core/src/main/scala/graviton/core/BlockStore.scala
@@ -5,6 +5,6 @@ import zio.stream.*
 
 trait BlockStore extends CasStore:
   def ingestBlocks(
-      chunker: ZSink[Any, Throwable, Byte, Byte, Chunk[BinaryKey.CasKey]]
+    chunker: ZSink[Any, Throwable, Byte, Byte, Chunk[BinaryKey.CasKey]]
   ): ZSink[Any, Throwable, Byte, Byte, Chunk[BinaryKey.CasKey]]
   def readBlock(key: BinaryKey.CasKey): IO[Throwable, Option[Bytes]]

--- a/modules/core/src/main/scala/graviton/core/CasStore.scala
+++ b/modules/core/src/main/scala/graviton/core/CasStore.scala
@@ -7,5 +7,5 @@ trait CasStore extends KeyedStore:
   def insert: ZSink[Any, Throwable, Byte, Byte, BinaryKey.CasKey]
   def findBinary(key: BinaryKey.CasKey): IO[Throwable, Option[Bytes]]
   def readAttributes(
-      key: BinaryKey.CasKey
+    key: BinaryKey.CasKey
   ): IO[Throwable, Option[BinaryAttributes]]

--- a/modules/core/src/main/scala/graviton/core/package.scala
+++ b/modules/core/src/main/scala/graviton/core/package.scala
@@ -7,6 +7,5 @@ import scala.collection.immutable.ListMap
 package object core:
   type Bytes = ZStream[Any, Throwable, Byte]
 
-
   given [K: Schema, V: Schema] => Schema[ListMap[K, V]] =
     Schema.list[((K, V))].transform(ListMap.from, _.toList)

--- a/modules/core/src/main/scala/graviton/hashing.scala
+++ b/modules/core/src/main/scala/graviton/hashing.scala
@@ -7,10 +7,11 @@ import io.github.rctcwyvrn.blake3.Blake3
 import io.github.iltotore.iron.*
 import io.github.iltotore.iron.constraint.all.*
 
-/** Helpers for computing hashes over byte streams. Supports both SHA variants
-  * (for FIPS deployments) and Blake3. Hashes are exposed via [[Hash]] which
-  * captures the algorithm alongside the digest bytes.
-  */
+/**
+ * Helpers for computing hashes over byte streams. Supports both SHA variants
+ * (for FIPS deployments) and Blake3. Hashes are exposed via [[Hash]] which
+ * captures the algorithm alongside the digest bytes.
+ */
 object Hashing:
 
   /** Create an incremental hasher for the chosen algorithm. */
@@ -30,7 +31,7 @@ object Hashing:
 
   /** A sink that consumes a byte stream and yields its digest. */
   def sink(
-      algo: HashAlgorithm
+    algo: HashAlgorithm
   ): ZSink[Any, Throwable, Byte, Nothing, Chunk[Byte]] =
     ZSink.unwrap {
       hasher(algo).map { h =>
@@ -40,20 +41,21 @@ object Hashing:
       }
     }
 
-  /** Produce a stream of rolling digests for the incoming byte stream. Each
-    * emitted [[Hash]] represents the digest of all bytes seen so far. This is a
-    * ZIO-port of fs2's `Scan` utility.
-    */
+  /**
+   * Produce a stream of rolling digests for the incoming byte stream. Each
+   * emitted [[Hash]] represents the digest of all bytes seen so far. This is a
+   * ZIO-port of fs2's `Scan` utility.
+   */
   def rolling(
-      stream: Bytes,
-      algo: HashAlgorithm
+    stream: Bytes,
+    algo: HashAlgorithm,
   ): ZStream[Any, Throwable, Hash] =
     ZStream.unwrap {
       hasher(algo).map { h =>
         stream.mapChunksZIO { chunk =>
           for
-            _ <- h.update(chunk)
-            dig <- h.snapshot
+            _      <- h.update(chunk)
+            dig    <- h.snapshot
             refined = dig.assume[MinLength[16] & MaxLength[64]]
           yield Chunk.single(Hash(refined, algo))
         }
@@ -74,24 +76,24 @@ object Hasher:
     new Hasher:
       def update(chunk: Chunk[Byte]): UIO[Unit] =
         ZIO.attempt(md.update(chunk.toArray)).orDie
-      def snapshot: UIO[Chunk[Byte]] =
+      def snapshot: UIO[Chunk[Byte]]            =
         ZIO
           .attempt(
             Chunk.fromArray(md.clone().asInstanceOf[MessageDigest].digest())
           )
           .orDie
-      def digest: UIO[Chunk[Byte]] =
+      def digest: UIO[Chunk[Byte]]              =
         ZIO.attempt(Chunk.fromArray(md.digest())).orDie
 
   /** Pure-Java Blake3 hasher. */
   def blake3: UIO[Hasher] =
     Ref.make(Vector.empty[Chunk[Byte]]).map { ref =>
       new Hasher:
-        def update(chunk: Chunk[Byte]): UIO[Unit] = ref.update(_ :+ chunk).unit
+        def update(chunk: Chunk[Byte]): UIO[Unit]                    = ref.update(_ :+ chunk).unit
         private def compute(parts: Vector[Chunk[Byte]]): Chunk[Byte] =
           val h = Blake3.newInstance()
           parts.foreach(ch => h.update(ch.toArray))
           Chunk.fromArray(h.digest())
-        def snapshot: UIO[Chunk[Byte]] = ref.get.map(compute)
-        def digest: UIO[Chunk[Byte]] = ref.getAndSet(Vector.empty).map(compute)
+        def snapshot: UIO[Chunk[Byte]]                               = ref.get.map(compute)
+        def digest: UIO[Chunk[Byte]]                                 = ref.getAndSet(Vector.empty).map(compute)
     }

--- a/modules/core/src/main/scala/graviton/impl/DefaultCopyTool.scala
+++ b/modules/core/src/main/scala/graviton/impl/DefaultCopyTool.scala
@@ -4,37 +4,38 @@ import graviton.*
 import graviton.core.BinaryAttributes
 import zio.*
 
-/** Default implementation of [[CopyTool]].
-  *
-  * Streams bytes from the source [[BinaryStore]] and writes them to the
-  * destination. Existing binaries can be skipped or overwritten based on the
-  * provided [[Hint]].
-  */
+/**
+ * Default implementation of [[CopyTool]].
+ *
+ * Streams bytes from the source [[BinaryStore]] and writes them to the
+ * destination. Existing binaries can be skipped or overwritten based on the
+ * provided [[Hint]].
+ */
 final class DefaultCopyTool extends CopyTool:
   private val DefaultChunkSize: Int = 64 * 1024
 
   def copy(
-      src: BinaryStore,
-      dest: BinaryStore,
-      id: BinaryId,
-      hint: Option[Hint] = None
+    src: BinaryStore,
+    dest: BinaryStore,
+    id: BinaryId,
+    hint: Option[Hint] = None,
   ): IO[Throwable, Unit] =
     val transfer = for
       bytes <- src
-        .get(id)
-        .someOrFail(GravitonError.NotFound(s"binary $id not found"))
-      _ <-
+                 .get(id)
+                 .someOrFail(GravitonError.NotFound(s"binary $id not found"))
+      _     <-
         bytes.run(dest.put(BinaryAttributes.empty, DefaultChunkSize)).unit
     yield ()
 
     for
       exists <- dest.exists(id)
-      _ <-
+      _      <-
         if exists then
           hint match
             case Some(Hint.Skip)      => ZIO.unit
             case Some(Hint.Overwrite) => transfer
-            case _ =>
+            case _                    =>
               ZIO.fail(
                 GravitonError.PolicyViolation(s"binary $id already exists")
               )

--- a/modules/core/src/main/scala/graviton/impl/EncryptedBlobStore.scala
+++ b/modules/core/src/main/scala/graviton/impl/EncryptedBlobStore.scala
@@ -4,26 +4,25 @@ import graviton.*
 import zio.*
 import zio.stream.*
 
-final class EncryptedBlobStore(delegate: BlobStore, encryption: Encryption)
-    extends BlobStore:
+final class EncryptedBlobStore(delegate: BlobStore, encryption: Encryption) extends BlobStore:
 
   def id: BlobStoreId = delegate.id
 
   def status: UIO[BlobStoreStatus] = delegate.status
 
   def read(
-      key: BlockKey,
-      range: Option[ByteRange] = None
+    key: BlockKey,
+    range: Option[ByteRange] = None,
   ): IO[Throwable, Option[Bytes]] =
     delegate.read(key, None).flatMap {
-      case None => ZIO.succeed(None)
+      case None        => ZIO.succeed(None)
       case Some(bytes) =>
         bytes.runCollect.flatMap { encrypted =>
           encryption.decrypt(key.hash, encrypted).map { plain =>
             val sliced = range match
               case Some(ByteRange(start, end)) =>
                 plain.drop(start.toInt).take((end - start).toInt)
-              case None => plain
+              case None                        => plain
             Some(Bytes(ZStream.fromChunk(sliced)))
           }
         }

--- a/modules/core/src/main/scala/graviton/impl/InMemoryBlobStore.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryBlobStore.scala
@@ -5,21 +5,21 @@ import zio.*
 import zio.stream.*
 
 final class InMemoryBlobStore private (
-    ref: Ref[Map[BlockKey, Chunk[Byte]]],
-    val id: BlobStoreId
+  ref: Ref[Map[BlockKey, Chunk[Byte]]],
+  val id: BlobStoreId,
 ) extends BlobStore:
 
   def status: UIO[BlobStoreStatus] = ZIO.succeed(BlobStoreStatus.Operational)
 
   def read(
-      key: BlockKey,
-      range: Option[ByteRange] = None
+    key: BlockKey,
+    range: Option[ByteRange] = None,
   ): IO[Throwable, Option[Bytes]] =
     ref.get.map(_.get(key).map { ch =>
       val sliced = range match
         case Some(ByteRange(start, end)) =>
           ch.drop(start.toInt).take((end - start).toInt)
-        case None => ch
+        case None                        => ch
       Bytes(ZStream.fromChunk(sliced))
     })
 

--- a/modules/core/src/main/scala/graviton/impl/InMemoryBlockResolver.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryBlockResolver.scala
@@ -4,7 +4,7 @@ import graviton.*
 import zio.*
 
 final class InMemoryBlockResolver private (
-    state: Ref[Map[BlockKey, Set[BlockSector]]]
+  state: Ref[Map[BlockKey, Set[BlockSector]]]
 ) extends BlockResolver:
   def record(key: BlockKey, sector: BlockSector): UIO[Unit] =
     state.update { m =>

--- a/modules/core/src/main/scala/graviton/impl/InMemoryBlockStore.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryBlockStore.scala
@@ -10,16 +10,16 @@ import java.time.Instant
 private final case class BlockState(refs: Int, unreferencedAt: Option[Instant])
 
 final class InMemoryBlockStore private (
-    index: Ref[Map[BlockKey, BlockState]],
-    stores: Map[BlobStoreId, BlobStore],
-    primary: BlobStore,
-    resolver: BlockResolver
+  index: Ref[Map[BlockKey, BlockState]],
+  stores: Map[BlobStoreId, BlobStore],
+  primary: BlobStore,
+  resolver: BlockResolver,
 ) extends BlockStore:
 
   def put: ZSink[Any, Throwable, Byte, Nothing, BlockKey] =
     ZSink.unwrap {
       for
-        chunks <- Ref.make(Vector.empty[Chunk[Byte]])
+        chunks  <- Ref.make(Vector.empty[Chunk[Byte]])
         sizeRef <- Ref.make(0)
       yield
         val collect =
@@ -31,44 +31,44 @@ final class InMemoryBlockStore private (
           .mapZIO { hashBytes =>
             val digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
             for
-              size <- sizeRef.get
-              key = BlockKey(
-                Hash(digest, HashAlgorithm.SHA256),
-                size.assume[Positive]
-              )
+              size     <- sizeRef.get
+              key       = BlockKey(
+                            Hash(digest, HashAlgorithm.SHA256),
+                            size.assume[Positive],
+                          )
               stateOpt <- index.get.map(_.get(key))
-              _ <- stateOpt match
-                case Some(state) =>
-                  index.update(
-                    _.updated(
-                      key,
-                      state.copy(refs = state.refs + 1, unreferencedAt = None)
-                    )
-                  )
-                case None =>
-                  for
-                    data <- chunks.get
-                      .map(chs => Bytes(ZStream.fromChunks(chs*)))
-                    _ <- primary.write(key, data)
-                    status <- primary.status
-                    _ <- resolver.record(key, BlockSector(primary.id, status))
-                    _ <- index.update(_ + (key -> BlockState(1, None)))
-                  yield ()
+              _        <- stateOpt match
+                            case Some(state) =>
+                              index.update(
+                                _.updated(
+                                  key,
+                                  state.copy(refs = state.refs + 1, unreferencedAt = None),
+                                )
+                              )
+                            case None        =>
+                              for
+                                data   <- chunks.get
+                                            .map(chs => Bytes(ZStream.fromChunks(chs*)))
+                                _      <- primary.write(key, data)
+                                status <- primary.status
+                                _      <- resolver.record(key, BlockSector(primary.id, status))
+                                _      <- index.update(_ + (key -> BlockState(1, None)))
+                              yield ()
             yield key
           }
     }
 
   def get(
-      key: BlockKey,
-      range: Option[ByteRange] = None
+    key: BlockKey,
+    range: Option[ByteRange] = None,
   ): IO[Throwable, Option[Bytes]] =
     resolver.resolve(key).flatMap { sectors =>
       def loop(rem: Chunk[BlockSector]): IO[Throwable, Option[Bytes]] =
         rem.headOption match
-          case None => ZIO.succeed(None)
+          case None      => ZIO.succeed(None)
           case Some(sec) =>
             stores.get(sec.blobStoreId) match
-              case None => loop(rem.drop(1))
+              case None        => loop(rem.drop(1))
               case Some(store) =>
                 store.read(key, range).flatMap {
                   case None => loop(rem.drop(1))
@@ -86,11 +86,10 @@ final class InMemoryBlockStore private (
         m.get(key) match
           case Some(state) if state.refs > 0 =>
             val updated =
-              if state.refs == 1 then
-                state.copy(refs = 0, unreferencedAt = Some(now))
+              if state.refs == 1 then state.copy(refs = 0, unreferencedAt = Some(now))
               else state.copy(refs = state.refs - 1, unreferencedAt = None)
             (true, m.updated(key, updated))
-          case _ => (false, m)
+          case _                             => (false, m)
       }
     }
 
@@ -98,7 +97,7 @@ final class InMemoryBlockStore private (
     ZStream.fromZIO(index.get).flatMap { set =>
       val all = set.collect { case (k, st) if st.refs > 0 => k }.toVector
       selector.prefix match
-        case None => ZStream.fromIterable(all)
+        case None    => ZStream.fromIterable(all)
         case Some(p) =>
           ZStream.fromIterable(
             all.filter(_.hash.bytes.take(p.length) == Chunk.fromArray(p))
@@ -107,25 +106,25 @@ final class InMemoryBlockStore private (
 
   def gc(config: GcConfig): UIO[Int] =
     for
-      now <- Clock.instant
+      now      <- Clock.instant
       toDelete <- index.modify { m =>
-        val (del, keep) = m.partition { case (_, st) =>
-          st.refs == 0 && st.unreferencedAt.exists { ts =>
-            val cutoff =
-              ts.plus(java.time.Duration.ofNanos(config.retention.toNanos))
-            cutoff.isBefore(now) || cutoff.equals(now)
-          }
-        }
-        (del.keySet, keep)
-      }
-      _ <- ZIO.foreachDiscard(toDelete)(k => primary.delete(k).ignore)
+                    val (del, keep) = m.partition { case (_, st) =>
+                      st.refs == 0 && st.unreferencedAt.exists { ts =>
+                        val cutoff =
+                          ts.plus(java.time.Duration.ofNanos(config.retention.toNanos))
+                        cutoff.isBefore(now) || cutoff.equals(now)
+                      }
+                    }
+                    (del.keySet, keep)
+                  }
+      _        <- ZIO.foreachDiscard(toDelete)(k => primary.delete(k).ignore)
     yield toDelete.size
 
 object InMemoryBlockStore:
   def make(
-      primary: BlobStore,
-      resolver: BlockResolver,
-      others: Seq[BlobStore] = Seq.empty
+    primary: BlobStore,
+    resolver: BlockResolver,
+    others: Seq[BlobStore] = Seq.empty,
   ): UIO[InMemoryBlockStore] =
     Ref.make(Map.empty[BlockKey, BlockState]).map { ref =>
       val all = (primary +: others).map(bs => bs.id -> bs).toMap

--- a/modules/core/src/main/scala/graviton/impl/InMemoryFileStore.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryFileStore.scala
@@ -7,70 +7,64 @@ import zio.*
 import zio.stream.*
 
 final class InMemoryFileStore private (
-    blockStore: BlockStore,
-    manifests: Ref[Map[FileKey, FileDescriptor]],
-    detect: ContentTypeDetect
+  blockStore: BlockStore,
+  manifests: Ref[Map[FileKey, FileDescriptor]],
+  detect: ContentTypeDetect,
 ) extends FileStore:
 
   def put(
-      attrs: BinaryAttributes,
-      blockSize: Int
+    attrs: BinaryAttributes,
+    blockSize: Int,
   ): ZSink[Any, Throwable, Byte, Nothing, FileKey] =
     ZSink.fromZIO(
       BinaryAttributes.validate(attrs).mapError(e => e: Throwable)
     ) *> {
-      val algo = HashAlgorithm.SHA256
+      val algo    = HashAlgorithm.SHA256
       val hashing = Hashing.sink(algo)
 
       val blockCollect: ZSink[Any, Throwable, Chunk[
         Byte
       ], Nothing, (Vector[BlockKey], Long)] =
-        ZSink.foldLeftZIO((Vector.empty[BlockKey], 0L)) {
-          case ((acc, sz), chunk) =>
-            ZStream.fromChunk(chunk).run(blockStore.put).map { key =>
-              (acc :+ key, sz + key.size.toLong)
-            }
+        ZSink.foldLeftZIO((Vector.empty[BlockKey], 0L)) { case ((acc, sz), chunk) =>
+          ZStream.fromChunk(chunk).run(blockStore.put).map { key =>
+            (acc :+ key, sz + key.size.toLong)
+          }
         }
 
-      val chunked
-          : ZSink[Any, Throwable, Byte, Nothing, (Vector[BlockKey], Long)] =
+      val chunked: ZSink[Any, Throwable, Byte, Nothing, (Vector[BlockKey], Long)] =
         FixedChunker(blockSize).pipeline >>> blockCollect
 
       hashing.zipPar(chunked).mapZIO { case (hash, (keys, size)) =>
-        val digest = hash
+        val digest    = hash
         val fileBytes = Bytes(
           ZStream
             .fromIterable(keys)
-            .mapZIO(b =>
-              blockStore.get(b).someOrFail(GravitonError.NotFound(b.hash.hex))
-            )
+            .mapZIO(b => blockStore.get(b).someOrFail(GravitonError.NotFound(b.hash.hex)))
             .flatMap(identity)
         )
         for
-          detected <- detect.detect(fileBytes)
+          detected    <- detect.detect(fileBytes)
           advertisedMt =
             attrs.getAdvertised(BinaryAttributeKey.contentType).map(_.value)
-          _ <- advertisedMt match
-            case Some(mt) if detected.exists(_ != mt) =>
-              ZIO.fail(GravitonError.PolicyViolation("media type mismatch"))
-            case _ => ZIO.unit
-          mediaType = advertisedMt
-            .orElse(detected)
-            .getOrElse("application/octet-stream")
-          fk = FileKey(Hash(digest, algo), algo, size, mediaType)
-          desc = FileDescriptor(fk, Chunk.fromIterable(keys), blockSize)
-          _ <- manifests.update(_ + (fk -> desc))
+          _           <- advertisedMt match
+                           case Some(mt) if detected.exists(_ != mt) =>
+                             ZIO.fail(GravitonError.PolicyViolation("media type mismatch"))
+                           case _                                    => ZIO.unit
+          mediaType    = advertisedMt
+                           .orElse(detected)
+                           .getOrElse("application/octet-stream")
+          fk           = FileKey(Hash(digest, algo), algo, size, mediaType)
+          desc         = FileDescriptor(fk, Chunk.fromIterable(keys), blockSize)
+          _           <- manifests.update(_ + (fk -> desc))
         yield fk
       }
     }
 
   def get(key: FileKey): IO[Throwable, Option[Bytes]] =
     describe(key).flatMap {
-      case None => ZIO.succeed(None)
+      case None     => ZIO.succeed(None)
       case Some(fd) =>
-        val streams = fd.blocks.map(b =>
-          blockStore.get(b).someOrFail(GravitonError.NotFound(b.hash.hex))
-        )
+        val streams = fd.blocks.map(b => blockStore.get(b).someOrFail(GravitonError.NotFound(b.hash.hex)))
         ZIO
           .foreach(streams)(identity)
           .map(parts => Some(Bytes(parts.reduceLeft(_ ++ _))))
@@ -92,15 +86,15 @@ final class InMemoryFileStore private (
           case Some(fd) => (Some(fd), m - key)
       }
       .flatMap {
-        case None => ZIO.succeed(false)
+        case None     => ZIO.succeed(false)
         case Some(fd) =>
           ZIO.foreachDiscard(fd.blocks)(blockStore.delete) *> ZIO.succeed(true)
       }
 
 object InMemoryFileStore:
   def make(
-      blockStore: BlockStore,
-      detect: ContentTypeDetect
+    blockStore: BlockStore,
+    detect: ContentTypeDetect,
   ): UIO[InMemoryFileStore] =
     Ref
       .make(Map.empty[FileKey, FileDescriptor])

--- a/modules/core/src/main/scala/graviton/merkle.scala
+++ b/modules/core/src/main/scala/graviton/merkle.scala
@@ -3,39 +3,38 @@ package graviton
 import zio.*
 import zio.stream.*
 
-/** Simple Merkle tree builder. The stream is split into fixed-size chunks, each
-  * leaf hashed individually, then paired up until a single root hash remains.
-  * For odd numbers of leaves the last hash is duplicated.
-  */
+/**
+ * Simple Merkle tree builder. The stream is split into fixed-size chunks, each
+ * leaf hashed individually, then paired up until a single root hash remains.
+ * For odd numbers of leaves the last hash is duplicated.
+ */
 object Merkle:
 
   def root(
-      stream: Bytes,
-      chunkSize: Int,
-      algo: HashAlgorithm
+    stream: Bytes,
+    chunkSize: Int,
+    algo: HashAlgorithm,
   ): UIO[Chunk[Byte]] =
     for
-      bytes <- stream.runCollect.orDie
-      groups = bytes.grouped(chunkSize).map(Chunk.fromIterable).toList
-      hashes <- ZIO.foreach(groups)(b =>
-        Hashing.compute(Bytes(ZStream.fromChunk(b)), algo)
-      )
-      root <- build(hashes, algo)
+      bytes  <- stream.runCollect.orDie
+      groups  = bytes.grouped(chunkSize).map(Chunk.fromIterable).toList
+      hashes <- ZIO.foreach(groups)(b => Hashing.compute(Bytes(ZStream.fromChunk(b)), algo))
+      root   <- build(hashes, algo)
     yield root
 
   private def build(
-      level: List[Chunk[Byte]],
-      algo: HashAlgorithm
+    level: List[Chunk[Byte]],
+    algo: HashAlgorithm,
   ): UIO[Chunk[Byte]] =
     level match
       case h :: Nil => ZIO.succeed(h)
-      case _ =>
+      case _        =>
         val next = level.grouped(2).toList.map {
           case a :: b :: Nil =>
             Hashing.compute(Bytes(ZStream.fromChunk(a ++ b)), algo)
-          case a :: Nil =>
+          case a :: Nil      =>
             // duplicate last hash when odd number of nodes
             Hashing.compute(Bytes(ZStream.fromChunk(a ++ a)), algo)
-          case _ => ZIO.dieMessage("unreachable")
+          case _             => ZIO.dieMessage("unreachable")
         }
         ZIO.collectAll(next).flatMap(build(_, algo))

--- a/modules/core/src/main/scala/graviton/stacked/StackedBinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/stacked/StackedBinaryStore.scala
@@ -7,14 +7,14 @@ import zio.*
 import zio.stream.*
 
 final case class StackedBinaryStore(
-    primary: BinaryStore,
-    replicas: Chunk[BinaryStore]
+  primary: BinaryStore,
+  replicas: Chunk[BinaryStore],
 ) extends BinaryStore:
   private val allStores: Chunk[BinaryStore] = primary +: replicas
 
   def put(
-      attrs: BinaryAttributes,
-      chunkSize: Int
+    attrs: BinaryAttributes,
+    chunkSize: Int,
   ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
     ZSink.collectAll[Byte].mapZIO { data =>
       ZIO
@@ -30,21 +30,21 @@ final case class StackedBinaryStore(
         }
         .flatMap {
           case head :: _ => ZIO.succeed(head)
-          case Nil =>
+          case Nil       =>
             ZIO.fail(BackendUnavailable("all replicas failed"))
         }
     }
 
   def get(
-      id: BinaryId,
-      range: Option[ByteRange] = None
+    id: BinaryId,
+    range: Option[ByteRange] = None,
   ): IO[Throwable, Option[Bytes]] =
     def loop(
-        stores: Chunk[BinaryStore],
-        lastErr: Option[Throwable]
+      stores: Chunk[BinaryStore],
+      lastErr: Option[Throwable],
     ): IO[Throwable, Option[Bytes]] =
       stores.headOption match
-        case None =>
+        case None        =>
           lastErr match
             case Some(err) => ZIO.fail(err)
             case None      => ZIO.succeed(None)

--- a/modules/core/src/main/scala/graviton/timeseries/TimeSeries.scala
+++ b/modules/core/src/main/scala/graviton/timeseries/TimeSeries.scala
@@ -3,32 +3,31 @@ package graviton.timeseries
 import graviton.Scan
 import zio.Chunk
 
-/** Simple time-series oriented scans ported from fs2-timeseries.
-  */
+/**
+ * Simple time-series oriented scans ported from fs2-timeseries.
+ */
 object TimeSeries:
 
-  /** Emits the difference between consecutive numeric inputs. First element is
-    * emitted unchanged.
-    */
+  /**
+   * Emits the difference between consecutive numeric inputs. First element is
+   * emitted unchanged.
+   */
   def delta[A](using num: Numeric[A]): Scan.Aux[A, A, Tuple1[Option[A]]] =
     Scan.statefulTuple(Tuple1(Option.empty[A])) { (st, a: A) =>
       val prev = st._1
-      val out = prev.map(p => num.minus(a, p)).getOrElse(a)
+      val out  = prev.map(p => num.minus(a, p)).getOrElse(a)
       (Tuple1(Some(a)), Chunk.single(out))
     }(_ => Chunk.empty)
 
   /** Moving average over a sliding window of size `n`. */
-  def movingAverage[A](n: Int)(using
-      num: Fractional[A]
-  ): Scan.Aux[A, A, Tuple2[List[A], A]] =
+  def movingAverage[A](n: Int)(using num: Fractional[A]): Scan.Aux[A, A, Tuple2[List[A], A]] =
     import num.*
     require(n > 0, "window size must be positive")
-    Scan.statefulTuple[A, A, Tuple2[List[A], A]]((List.empty[A], num.zero)) {
-      case ((buf, sum), d) =>
-        val buf1 = (d :: buf).take(n)
-        val sum1 = (sum + d) - (if buf.size >= n then buf.last else num.zero)
-        val avg = sum1 / num.fromInt(buf1.size)
-        ((buf1, sum1), Chunk.single(avg))
+    Scan.statefulTuple[A, A, Tuple2[List[A], A]]((List.empty[A], num.zero)) { case ((buf, sum), d) =>
+      val buf1 = (d :: buf).take(n)
+      val sum1 = (sum + d) - (if buf.size >= n then buf.last else num.zero)
+      val avg  = sum1 / num.fromInt(buf1.size)
+      ((buf1, sum1), Chunk.single(avg))
     }(_ => Chunk.empty)
 
   /** Count elements per fixed-size window using a tumbling strategy. */

--- a/modules/core/src/test/scala/graviton/ArrowSpec.scala
+++ b/modules/core/src/test/scala/graviton/ArrowSpec.scala
@@ -6,22 +6,22 @@ import zio.test.*
 object ArrowSpec extends ZIOSpecDefault:
   def spec = suite("ArrowSpec")(
     test("composition inverts and records labels") {
-      val xor = InvertibleArrow.lift[Chunk[Byte], Chunk[Byte]](
+      val xor       = InvertibleArrow.lift[Chunk[Byte], Chunk[Byte]](
         label = "xor",
         inverse = "xor",
-        "key" -> 0x0f
+        "key" -> 0x0f,
       )
-      val rev = InvertibleArrow.lift[Chunk[Byte], Chunk[Byte]](
+      val rev       = InvertibleArrow.lift[Chunk[Byte], Chunk[Byte]](
         label = "reverse",
-        inverse = "reverse"
+        inverse = "reverse",
       )
-      val arrow = xor >>> rev
-      val labels = arrow.steps.map(_.label)
+      val arrow     = xor >>> rev
+      val labels    = arrow.steps.map(_.label)
       val invLabels = arrow.invert.steps.map(_.label)
       assertTrue(
         labels == Chunk("xor", "reverse") && invLabels == Chunk(
           "reverse",
-          "xor"
+          "xor",
         )
       )
     }

--- a/modules/core/src/test/scala/graviton/BlockStoreSpec.scala
+++ b/modules/core/src/test/scala/graviton/BlockStoreSpec.scala
@@ -12,70 +12,70 @@ object BlockStoreSpec extends ZIOSpecDefault:
   def spec = suite("BlockStoreSpec")(
     test("put/get/has/delete") {
       for
-        blob <- InMemoryBlobStore.make()
+        blob     <- InMemoryBlobStore.make()
         resolver <- InMemoryBlockResolver.make
-        store <- InMemoryBlockStore.make(blob, resolver)
-        key <- ZStream
-          .fromIterable("hello world".getBytes.toIndexedSeq)
-          .run(store.put)
-        has <- store.has(key)
-        data <- store.get(key).someOrFailException.flatMap(_.runCollect)
-        del <- store.delete(key)
+        store    <- InMemoryBlockStore.make(blob, resolver)
+        key      <- ZStream
+                      .fromIterable("hello world".getBytes.toIndexedSeq)
+                      .run(store.put)
+        has      <- store.has(key)
+        data     <- store.get(key).someOrFailException.flatMap(_.runCollect)
+        del      <- store.delete(key)
       yield assertTrue(has && new String(data.toArray) == "hello world" && del)
     },
     test("consult resolver across stores") {
       for
-        primary <- InMemoryBlobStore.make()
+        primary   <- InMemoryBlobStore.make()
         secondary <- InMemoryBlobStore.make()
-        resolver <- InMemoryBlockResolver.make
-        store <- InMemoryBlockStore.make(primary, resolver, Seq(secondary))
-        key <- ZStream
-          .fromIterable("hello".getBytes.toIndexedSeq)
-          .run(store.put)
-        _ <- secondary.write(key, Bytes(ZStream.fromIterable("hello".getBytes)))
-        _ <- resolver.record(
-          key,
-          BlockSector(secondary.id, BlobStoreStatus.Operational)
-        )
-        _ <- primary.delete(key)
-        data <- store.get(key).someOrFailException.flatMap(_.runCollect)
+        resolver  <- InMemoryBlockResolver.make
+        store     <- InMemoryBlockStore.make(primary, resolver, Seq(secondary))
+        key       <- ZStream
+                       .fromIterable("hello".getBytes.toIndexedSeq)
+                       .run(store.put)
+        _         <- secondary.write(key, Bytes(ZStream.fromIterable("hello".getBytes)))
+        _         <- resolver.record(
+                       key,
+                       BlockSector(secondary.id, BlobStoreStatus.Operational),
+                     )
+        _         <- primary.delete(key)
+        data      <- store.get(key).someOrFailException.flatMap(_.runCollect)
       yield assertTrue(new String(data.toArray) == "hello")
     },
     test("partial reads") {
       for
-        blob <- InMemoryBlobStore.make()
+        blob     <- InMemoryBlobStore.make()
         resolver <- InMemoryBlockResolver.make
-        store <- InMemoryBlockStore.make(blob, resolver)
-        key <- ZStream
-          .fromIterable("hello world".getBytes.toIndexedSeq)
-          .run(store.put)
-        part <- store
-          .get(key, Some(ByteRange(6, 11)))
-          .someOrFailException
-          .flatMap(_.runCollect)
+        store    <- InMemoryBlockStore.make(blob, resolver)
+        key      <- ZStream
+                      .fromIterable("hello world".getBytes.toIndexedSeq)
+                      .run(store.put)
+        part     <- store
+                      .get(key, Some(ByteRange(6, 11)))
+                      .someOrFailException
+                      .flatMap(_.runCollect)
       yield assertTrue(new String(part.toArray) == "world")
     },
     test(
       "gc removes unreferenced blocks after retention and preserves live data"
     ) {
       for
-        blob <- InMemoryBlobStore.make()
+        blob     <- InMemoryBlobStore.make()
         resolver <- InMemoryBlockResolver.make
-        store <- InMemoryBlockStore.make(blob, resolver)
-        key <- ZStream
-          .fromIterable("hello".getBytes.toIndexedSeq)
-          .run(store.put)
-        _ <- ZStream
-          .fromIterable("hello".getBytes.toIndexedSeq)
-          .run(store.put)
-        _ <- store.delete(key)
-        _ <- TestClock.adjust(1.second)
+        store    <- InMemoryBlockStore.make(blob, resolver)
+        key      <- ZStream
+                      .fromIterable("hello".getBytes.toIndexedSeq)
+                      .run(store.put)
+        _        <- ZStream
+                      .fromIterable("hello".getBytes.toIndexedSeq)
+                      .run(store.put)
+        _        <- store.delete(key)
+        _        <- TestClock.adjust(1.second)
         removed0 <- store.gc(GcConfig(1.second))
-        still <- store.has(key)
-        _ <- store.delete(key)
-        _ <- TestClock.adjust(1.second)
-        removed <- store.gc(GcConfig(1.second))
-        gone <- store.has(key)
+        still    <- store.has(key)
+        _        <- store.delete(key)
+        _        <- TestClock.adjust(1.second)
+        removed  <- store.gc(GcConfig(1.second))
+        gone     <- store.has(key)
       yield assertTrue(removed0 == 0 && still && removed == 1 && !gone)
-    }
+    },
   )

--- a/modules/core/src/test/scala/graviton/ChunkerSpec.scala
+++ b/modules/core/src/test/scala/graviton/ChunkerSpec.scala
@@ -10,46 +10,45 @@ import java.io.ByteArrayOutputStream
 object ChunkerSpec extends ZIOSpecDefault:
 
   private def compress(data: Array[Byte], level: Int): Array[Byte] =
-    val bos = new ByteArrayOutputStream()
+    val bos  = new ByteArrayOutputStream()
     val defl = new Deflater(level)
-    val dos = new DeflaterOutputStream(bos, defl)
+    val dos  = new DeflaterOutputStream(bos, defl)
     dos.write(data)
     dos.finish()
     bos.toByteArray
 
   private def pdfWith(data: Array[Byte], level: Int): Chunk[Byte] =
-    val comp = compress(data, level)
-    val dict = s"<< /Length ${comp.length} /Filter /FlateDecode >>\n".getBytes(
+    val comp   = compress(data, level)
+    val dict   = s"<< /Length ${comp.length} /Filter /FlateDecode >>\n".getBytes(
       "ISO-8859-1"
     )
-    val pre = "%PDF-1.4\n1 0 obj\n".getBytes("ISO-8859-1")
+    val pre    = "%PDF-1.4\n1 0 obj\n".getBytes("ISO-8859-1")
     val stream = "stream\n".getBytes("ISO-8859-1")
-    val end = "\nendstream\nendobj\n".getBytes("ISO-8859-1")
+    val end    = "\nendstream\nendobj\n".getBytes("ISO-8859-1")
     Chunk.fromArray(pre ++ dict ++ stream ++ comp ++ end)
 
   def spec = suite("ChunkerSpec")(
     test("fixed chunker splits by size") {
       val data = Chunk.fromArray("abcdef".getBytes("UTF-8"))
-      ZStream.fromChunk(data).via(FixedChunker(2).pipeline).runCollect.map {
-        out =>
-          assertTrue(
-            out == Chunk(
-              Chunk.fromArray("ab".getBytes),
-              Chunk.fromArray("cd".getBytes),
-              Chunk.fromArray("ef".getBytes)
-            )
+      ZStream.fromChunk(data).via(FixedChunker(2).pipeline).runCollect.map { out =>
+        assertTrue(
+          out == Chunk(
+            Chunk.fromArray("ab".getBytes),
+            Chunk.fromArray("cd".getBytes),
+            Chunk.fromArray("ef".getBytes),
           )
+        )
       }
     },
     test("pdf chunker normalizes compressed streams") {
       val content = "hello pdf".getBytes("UTF-8")
-      val pdf1 = pdfWith(content, Deflater.BEST_SPEED)
-      val pdf2 = pdfWith(content, Deflater.BEST_COMPRESSION)
+      val pdf1    = pdfWith(content, Deflater.BEST_SPEED)
+      val pdf2    = pdfWith(content, Deflater.BEST_COMPRESSION)
       for
         c1 <- ZStream.fromChunk(pdf1).via(PdfChunker.pipeline).runCollect
         c2 <- ZStream.fromChunk(pdf2).via(PdfChunker.pipeline).runCollect
       yield assertTrue(
         c1 == c2 && c1.exists(_ == Chunk.fromArray(content))
       )
-    }
+    },
   )

--- a/modules/core/src/test/scala/graviton/FileStoreSpec.scala
+++ b/modules/core/src/test/scala/graviton/FileStoreSpec.scala
@@ -13,45 +13,45 @@ object FileStoreSpec extends ZIOSpecDefault:
       val detect = new ContentTypeDetect:
         def detect(bytes: Bytes) = ZIO.succeed(Some("text/plain"))
       for
-        blob <- InMemoryBlobStore.make()
+        blob     <- InMemoryBlobStore.make()
         resolver <- InMemoryBlockResolver.make
-        blocks <- InMemoryBlockStore.make(blob, resolver)
-        files <- InMemoryFileStore.make(blocks, detect)
-        attrs =
+        blocks   <- InMemoryBlockStore.make(blob, resolver)
+        files    <- InMemoryFileStore.make(blocks, detect)
+        attrs     =
           BinaryAttributes
             .advertised(BinaryAttributeKey.filename, "t.txt", "client") ++
             BinaryAttributes.advertised(
               BinaryAttributeKey.contentType,
               "text/plain",
-              "client"
+              "client",
             )
-        fk <- ZStream
-          .fromIterable("abc" * 1000)
-          .map(_.toByte)
-          .run(files.put(attrs, 64 * 1024))
-        out <- files.get(fk).someOrFailException.flatMap(_.runCollect)
+        fk       <- ZStream
+                      .fromIterable("abc" * 1000)
+                      .map(_.toByte)
+                      .run(files.put(attrs, 64 * 1024))
+        out      <- files.get(fk).someOrFailException.flatMap(_.runCollect)
       yield assertTrue(out.length == 3000)
     },
     test("mismatched content type fails") {
-      val detect = new ContentTypeDetect:
+      val detect  = new ContentTypeDetect:
         def detect(bytes: Bytes) = ZIO.succeed(Some("text/plain"))
       val attempt = for
-        blob <- InMemoryBlobStore.make()
+        blob     <- InMemoryBlobStore.make()
         resolver <- InMemoryBlockResolver.make
-        blocks <- InMemoryBlockStore.make(blob, resolver)
-        files <- InMemoryFileStore.make(blocks, detect)
-        attrs =
+        blocks   <- InMemoryBlockStore.make(blob, resolver)
+        files    <- InMemoryFileStore.make(blocks, detect)
+        attrs     =
           BinaryAttributes
             .advertised(BinaryAttributeKey.filename, "d.png", "client") ++
             BinaryAttributes.advertised(
               BinaryAttributeKey.contentType,
               "image/png",
-              "client"
+              "client",
             )
-        _ <- ZStream
-          .fromIterable("data".getBytes.toIndexedSeq)
-          .run(files.put(attrs, 64 * 1024))
+        _        <- ZStream
+                      .fromIterable("data".getBytes.toIndexedSeq)
+                      .run(files.put(attrs, 64 * 1024))
       yield ()
-      attempt.exit.map { exit => assertTrue(exit.isFailure) }
-    }
+      attempt.exit.map(exit => assertTrue(exit.isFailure))
+    },
   )

--- a/modules/core/src/test/scala/graviton/HashingSpec.scala
+++ b/modules/core/src/test/scala/graviton/HashingSpec.scala
@@ -11,7 +11,7 @@ object HashingSpec extends ZIOSpecDefault:
         Bytes(ZStream.fromIterable("hello world".getBytes.toIndexedSeq))
       for
         sha <- Hashing.compute(bytes, HashAlgorithm.SHA256)
-        bl <- Hashing.compute(bytes, HashAlgorithm.Blake3)
+        bl  <- Hashing.compute(bytes, HashAlgorithm.Blake3)
       yield assertTrue(
         sha.toArray
           .map("%02x".format(_))
@@ -25,19 +25,19 @@ object HashingSpec extends ZIOSpecDefault:
       val stream = Bytes(
         ZStream.fromChunks(
           Chunk.fromArray("ab".getBytes),
-          Chunk.fromArray("cd".getBytes)
+          Chunk.fromArray("cd".getBytes),
         )
       )
       for
-        hashes <- Hashing.rolling(stream, HashAlgorithm.SHA256).runCollect
-        expectedFirst <- Hashing.compute(
-          Bytes(ZStream.fromIterable("ab".getBytes.toIndexedSeq)),
-          HashAlgorithm.SHA256
-        )
+        hashes         <- Hashing.rolling(stream, HashAlgorithm.SHA256).runCollect
+        expectedFirst  <- Hashing.compute(
+                            Bytes(ZStream.fromIterable("ab".getBytes.toIndexedSeq)),
+                            HashAlgorithm.SHA256,
+                          )
         expectedSecond <- Hashing.compute(
-          Bytes(ZStream.fromIterable("abcd".getBytes.toIndexedSeq)),
-          HashAlgorithm.SHA256
-        )
+                            Bytes(ZStream.fromIterable("abcd".getBytes.toIndexedSeq)),
+                            HashAlgorithm.SHA256,
+                          )
       yield assertTrue(
         hashes.map(_.bytes) == Chunk(expectedFirst, expectedSecond)
       )
@@ -45,9 +45,9 @@ object HashingSpec extends ZIOSpecDefault:
     test("sink computes digest without buffering entire stream") {
       val data = Chunk.fromArray("hello world".getBytes)
       for
-        dig <- ZStream.fromChunk(data).run(Hashing.sink(HashAlgorithm.SHA256))
+        dig      <- ZStream.fromChunk(data).run(Hashing.sink(HashAlgorithm.SHA256))
         expected <- Hashing
-          .compute(Bytes(ZStream.fromChunk(data)), HashAlgorithm.SHA256)
+                      .compute(Bytes(ZStream.fromChunk(data)), HashAlgorithm.SHA256)
       yield assertTrue(dig == expected)
-    }
+    },
   )

--- a/modules/core/src/test/scala/graviton/RangeSpec.scala
+++ b/modules/core/src/test/scala/graviton/RangeSpec.scala
@@ -9,8 +9,8 @@ object RangeSpec extends ZIOSpecDefault:
     test("basic contains and iteration") {
       given Discrete[Int] = Discrete.integralDiscrete[Int]
       given Ordering[Int] = Ordering.Int
-      val r = Range(1, 5)
-      val list = r.toList
+      val r               = Range(1, 5)
+      val list            = r.toList
       assertTrue(r.contains(3), list == List(1, 2, 3, 4, 5))
     }
   )

--- a/modules/core/src/test/scala/graviton/TimeSeriesSpec.scala
+++ b/modules/core/src/test/scala/graviton/TimeSeriesSpec.scala
@@ -23,5 +23,5 @@ object TimeSeriesSpec extends ZIOSpecDefault:
       val scan = TimeSeries.countWindow(3)
       for out <- ZStream.range(0, 7).via(scan.toPipeline).runCollect
       yield assertTrue(out == Chunk(3, 3, 1))
-    }
+    },
   )

--- a/modules/core/src/test/scala/graviton/logging/LoggingBinaryStoreSpec.scala
+++ b/modules/core/src/test/scala/graviton/logging/LoggingBinaryStoreSpec.scala
@@ -11,13 +11,13 @@ import zio.test.ZTestLogger
 object LoggingBinaryStoreSpec extends ZIOSpecDefault:
   private val dummyStore = new BinaryStore:
     def put(
-        attrs: BinaryAttributes,
-        chunkSize: Int
+      attrs: BinaryAttributes,
+      chunkSize: Int,
     ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
       ZSink.fail(new NotImplementedError("unused"))
     def get(
-        id: BinaryId,
-        range: Option[ByteRange]
+      id: BinaryId,
+      range: Option[ByteRange],
     ): IO[Throwable, Option[graviton.Bytes]] =
       ZIO.succeed(None)
     def delete(id: BinaryId): IO[Throwable, Boolean] = ZIO.succeed(true)
@@ -28,11 +28,11 @@ object LoggingBinaryStoreSpec extends ZIOSpecDefault:
       test("logs once when applied multiple times") {
         val store = LoggingBinaryStore(LoggingBinaryStore(dummyStore))
         for
-          _ <- store.exists(BinaryId("1"))
-          logs <- ZTestLogger.logOutput
-          start = logs.count(_.message() == "exists start")
+          _     <- store.exists(BinaryId("1"))
+          logs  <- ZTestLogger.logOutput
+          start  = logs.count(_.message() == "exists start")
           finish = logs.count(_.message() == "exists finish")
-          ids = logs.map(_.annotations.get("correlation-id"))
+          ids    = logs.map(_.annotations.get("correlation-id"))
         yield assertTrue(start == 1, finish == 1, ids.flatten.toSet.size == 1)
       }
     ).provideLayer(ZTestLogger.default)

--- a/modules/fs/src/main/scala/graviton/fs/DiskCacheStore.scala
+++ b/modules/fs/src/main/scala/graviton/fs/DiskCacheStore.scala
@@ -7,28 +7,29 @@ import zio.stream.*
 import zio.Duration
 import java.nio.file.{Files, Path}
 
-/** Local-disk [[CacheStore]] backed by [[zio.cache.Cache]]. Cached entries are
-  * stored under `root/<hash-hex>` and validated against the expected hash
-  * before being served.
-  */
+/**
+ * Local-disk [[CacheStore]] backed by [[zio.cache.Cache]]. Cached entries are
+ * stored under `root/<hash-hex>` and validated against the expected hash
+ * before being served.
+ */
 final class DiskCacheStore private (
-    root: Path,
-    cache: Cache[Hash, Throwable, Chunk[Byte]],
-    loaderRef: FiberRef[Hash => Task[Chunk[Byte]]]
+  root: Path,
+  cache: Cache[Hash, Throwable, Chunk[Byte]],
+  loaderRef: FiberRef[Hash => Task[Chunk[Byte]]],
 ) extends CacheStore:
 
   private def fromChunk(ch: Chunk[Byte]): Bytes = Bytes(ZStream.fromChunk(ch))
 
   def fetch(
-      hash: Hash,
-      download: => Task[Bytes],
-      useCache: Boolean
+    hash: Hash,
+    download: => Task[Bytes],
+    useCache: Boolean,
   ): Task[Bytes] =
     if !useCache then
       for
-        data <- download
+        data  <- download
         chunk <- data.runCollect
-        _ <- DiskCacheStore.verify(hash, chunk)
+        _     <- DiskCacheStore.verify(hash, chunk)
       yield fromChunk(chunk)
     else
       loaderRef.locally((_: Hash) => download.flatMap(_.runCollect)) {
@@ -43,33 +44,33 @@ object DiskCacheStore:
   private def verify(hash: Hash, data: Chunk[Byte]): Task[Unit] =
     for
       dig <- Hashing.compute(Bytes(ZStream.fromChunk(data)), hash.algo)
-      _ <- ZIO
-        .fail(RuntimeException("hash mismatch"))
-        .unless(dig == hash.bytes)
+      _   <- ZIO
+               .fail(RuntimeException("hash mismatch"))
+               .unless(dig == hash.bytes)
     yield ()
 
   private def loader(
-      root: Path,
-      ref: FiberRef[Hash => Task[Chunk[Byte]]]
+    root: Path,
+    ref: FiberRef[Hash => Task[Chunk[Byte]]],
   )(hash: Hash): Task[Chunk[Byte]] =
-    val path = root.resolve(hash.hex)
+    val path                                = root.resolve(hash.hex)
     def downloadAndWrite: Task[Chunk[Byte]] =
       for
         remote <- ref.get
-        chunk <- remote(hash)
-        _ <- verify(hash, chunk)
-        _ <- ZIO.attempt(Files.createDirectories(path.getParent))
-        _ <- ZIO.attempt(Files.write(path, chunk.toArray))
+        chunk  <- remote(hash)
+        _      <- verify(hash, chunk)
+        _      <- ZIO.attempt(Files.createDirectories(path.getParent))
+        _      <- ZIO.attempt(Files.write(path, chunk.toArray))
       yield chunk
     for
       exists <- ZIO.attempt(Files.exists(path))
-      chunk <-
+      chunk  <-
         if exists then
           for
             arr <- ZIO.attempt(Files.readAllBytes(path)).map(Chunk.fromArray)
-            ok <- Hashing
-              .compute(Bytes(ZStream.fromChunk(arr)), hash.algo)
-              .map(_ == hash.bytes)
+            ok  <- Hashing
+                     .compute(Bytes(ZStream.fromChunk(arr)), hash.algo)
+                     .map(_ == hash.bytes)
             res <- if ok then ZIO.succeed(arr) else downloadAndWrite
           yield res
         else downloadAndWrite
@@ -77,24 +78,22 @@ object DiskCacheStore:
 
   /** Construct a [[DiskCacheStore]]. */
   def make(
-      root: Path,
-      capacity: Int = 1024,
-      ttl: Duration = Duration.Infinity
+    root: Path,
+    capacity: Int = 1024,
+    ttl: Duration = Duration.Infinity,
   ): ZIO[Scope, Nothing, DiskCacheStore] =
     for
-      ref <- FiberRef.make[Hash => Task[Chunk[Byte]]]((_: Hash) =>
-        ZIO.fail(RuntimeException("no loader"))
-      )
+      ref   <- FiberRef.make[Hash => Task[Chunk[Byte]]]((_: Hash) => ZIO.fail(RuntimeException("no loader")))
       cache <- Cache.make[Hash, Any, Throwable, Chunk[Byte]](
-        capacity,
-        ttl,
-        Lookup(loader(root, ref))
-      )
+                 capacity,
+                 ttl,
+                 Lookup(loader(root, ref)),
+               )
     yield DiskCacheStore(root, cache, ref)
 
   def layer(
-      root: Path,
-      capacity: Int = 1024,
-      ttl: Duration = Duration.Infinity
+    root: Path,
+    capacity: Int = 1024,
+    ttl: Duration = Duration.Infinity,
   ): ZLayer[Any, Nothing, CacheStore] =
     ZLayer.scoped(make(root, capacity, ttl))

--- a/modules/fs/src/main/scala/graviton/fs/RocksDBCacheStore.scala
+++ b/modules/fs/src/main/scala/graviton/fs/RocksDBCacheStore.scala
@@ -6,30 +6,31 @@ import zio.cache.*
 import zio.stream.*
 import zio.Duration
 import java.nio.file.Path
-import zio.rocksdb.{RocksDB as ZRocksDB}
+import zio.rocksdb.RocksDB as ZRocksDB
 
-/** [[CacheStore]] backed by RocksDB for persistent storage. Cached entries are
-  * keyed by the hex representation of the [[Hash]] and validated against the
-  * expected digest before use.
-  */
+/**
+ * [[CacheStore]] backed by RocksDB for persistent storage. Cached entries are
+ * keyed by the hex representation of the [[Hash]] and validated against the
+ * expected digest before use.
+ */
 final class RocksDBCacheStore private (
-    db: ZRocksDB,
-    cache: Cache[Hash, Throwable, Chunk[Byte]],
-    loaderRef: FiberRef[Hash => Task[Chunk[Byte]]]
+  db: ZRocksDB,
+  cache: Cache[Hash, Throwable, Chunk[Byte]],
+  loaderRef: FiberRef[Hash => Task[Chunk[Byte]]],
 ) extends CacheStore:
 
   private def fromChunk(ch: Chunk[Byte]): Bytes = Bytes(ZStream.fromChunk(ch))
 
   def fetch(
-      hash: Hash,
-      download: => Task[Bytes],
-      useCache: Boolean
+    hash: Hash,
+    download: => Task[Bytes],
+    useCache: Boolean,
   ): Task[Bytes] =
     if !useCache then
       for
-        data <- download
+        data  <- download
         chunk <- data.runCollect
-        _ <- RocksDBCacheStore.verify(hash, chunk)
+        _     <- RocksDBCacheStore.verify(hash, chunk)
       yield fromChunk(chunk)
     else
       loaderRef.locally((_: Hash) => download.flatMap(_.runCollect)) {
@@ -44,62 +45,60 @@ object RocksDBCacheStore:
   private def verify(hash: Hash, data: Chunk[Byte]): Task[Unit] =
     for
       dig <- Hashing.compute(Bytes(ZStream.fromChunk(data)), hash.algo)
-      _ <- ZIO
-        .fail(RuntimeException("hash mismatch"))
-        .unless(dig == hash.bytes)
+      _   <- ZIO
+               .fail(RuntimeException("hash mismatch"))
+               .unless(dig == hash.bytes)
     yield ()
 
   private def loader(
-      db: ZRocksDB,
-      ref: FiberRef[Hash => Task[Chunk[Byte]]]
+    db: ZRocksDB,
+    ref: FiberRef[Hash => Task[Chunk[Byte]]],
   )(hash: Hash): Task[Chunk[Byte]] =
-    val key = hash.bytes.toArray
+    val key                                 = hash.bytes.toArray
     def downloadAndStore: Task[Chunk[Byte]] =
       for
         remote <- ref.get
-        chunk <- remote(hash)
-        _ <- verify(hash, chunk)
-        _ <- db.put(key, chunk.toArray)
+        chunk  <- remote(hash)
+        _      <- verify(hash, chunk)
+        _      <- db.put(key, chunk.toArray)
       yield chunk
     for
       existing <- db.get(key)
-      chunk <- existing match
-        case Some(arr) =>
-          for
-            ok <- Hashing
-              .compute(
-                Bytes(ZStream.fromChunk(Chunk.fromArray(arr))),
-                hash.algo
-              )
-              .map(_ == hash.bytes)
-            res <-
-              if ok then ZIO.succeed(Chunk.fromArray(arr)) else downloadAndStore
-          yield res
-        case None => downloadAndStore
+      chunk    <- existing match
+                    case Some(arr) =>
+                      for
+                        ok  <- Hashing
+                                 .compute(
+                                   Bytes(ZStream.fromChunk(Chunk.fromArray(arr))),
+                                   hash.algo,
+                                 )
+                                 .map(_ == hash.bytes)
+                        res <-
+                          if ok then ZIO.succeed(Chunk.fromArray(arr)) else downloadAndStore
+                      yield res
+                    case None      => downloadAndStore
     yield chunk
 
   /** Construct a [[RocksDBCacheStore]]. */
   def make(
-      path: Path,
-      capacity: Int = 1024,
-      ttl: Duration = Duration.Infinity
+    path: Path,
+    capacity: Int = 1024,
+    ttl: Duration = Duration.Infinity,
   ): ZIO[Scope, Throwable, RocksDBCacheStore] =
     for
-      env <- ZRocksDB.live(path.toString).build
-      db = env.get[ZRocksDB]
-      ref <- FiberRef.make[Hash => Task[Chunk[Byte]]]((_: Hash) =>
-        ZIO.fail(RuntimeException("no loader"))
-      )
+      env   <- ZRocksDB.live(path.toString).build
+      db     = env.get[ZRocksDB]
+      ref   <- FiberRef.make[Hash => Task[Chunk[Byte]]]((_: Hash) => ZIO.fail(RuntimeException("no loader")))
       cache <- Cache.make[Hash, Any, Throwable, Chunk[Byte]](
-        capacity,
-        ttl,
-        Lookup(loader(db, ref))
-      )
+                 capacity,
+                 ttl,
+                 Lookup(loader(db, ref)),
+               )
     yield RocksDBCacheStore(db, cache, ref)
 
   def layer(
-      path: Path,
-      capacity: Int = 1024,
-      ttl: Duration = Duration.Infinity
+    path: Path,
+    capacity: Int = 1024,
+    ttl: Duration = Duration.Infinity,
   ): ZLayer[Any, Throwable, CacheStore] =
     ZLayer.scoped(make(path, capacity, ttl))

--- a/modules/fs/src/test/scala/graviton/fs/DiskCacheStoreSpec.scala
+++ b/modules/fs/src/test/scala/graviton/fs/DiskCacheStoreSpec.scala
@@ -14,38 +14,38 @@ object DiskCacheStoreSpec extends ZIOSpecDefault:
     suite("DiskCacheStore")(
       test("caches downloads when enabled") {
         for
-          dir <- ZIO.attempt(Files.createTempDirectory("cache-test"))
-          store <- DiskCacheStore.make(dir)
-          ref <- Ref.make(0)
-          data = "hello".getBytes.toIndexedSeq
+          dir       <- ZIO.attempt(Files.createTempDirectory("cache-test"))
+          store     <- DiskCacheStore.make(dir)
+          ref       <- Ref.make(0)
+          data       = "hello".getBytes.toIndexedSeq
           hashBytes <- Hashing.compute(
-            Bytes(ZStream.fromIterable(data)),
-            HashAlgorithm.SHA256
-          )
-          digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
-          hash = Hash(digest, HashAlgorithm.SHA256)
-          remote = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
-          _ <- store.fetch(hash, remote, useCache = true)
-          _ <- store.fetch(hash, remote, useCache = true)
-          calls <- ref.get
+                         Bytes(ZStream.fromIterable(data)),
+                         HashAlgorithm.SHA256,
+                       )
+          digest     = hashBytes.assume[MinLength[16] & MaxLength[64]]
+          hash       = Hash(digest, HashAlgorithm.SHA256)
+          remote     = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
+          _         <- store.fetch(hash, remote, useCache = true)
+          _         <- store.fetch(hash, remote, useCache = true)
+          calls     <- ref.get
         yield assertTrue(calls == 1)
       },
       test("bypasses cache when disabled") {
         for
-          dir <- ZIO.attempt(Files.createTempDirectory("cache-test"))
-          store <- DiskCacheStore.make(dir)
-          ref <- Ref.make(0)
-          data = "hello".getBytes.toIndexedSeq
+          dir       <- ZIO.attempt(Files.createTempDirectory("cache-test"))
+          store     <- DiskCacheStore.make(dir)
+          ref       <- Ref.make(0)
+          data       = "hello".getBytes.toIndexedSeq
           hashBytes <- Hashing.compute(
-            Bytes(ZStream.fromIterable(data)),
-            HashAlgorithm.SHA256
-          )
-          digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
-          hash = Hash(digest, HashAlgorithm.SHA256)
-          remote = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
-          _ <- store.fetch(hash, remote, useCache = false)
-          _ <- store.fetch(hash, remote, useCache = false)
-          calls <- ref.get
+                         Bytes(ZStream.fromIterable(data)),
+                         HashAlgorithm.SHA256,
+                       )
+          digest     = hashBytes.assume[MinLength[16] & MaxLength[64]]
+          hash       = Hash(digest, HashAlgorithm.SHA256)
+          remote     = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
+          _         <- store.fetch(hash, remote, useCache = false)
+          _         <- store.fetch(hash, remote, useCache = false)
+          calls     <- ref.get
         yield assertTrue(calls == 2)
-      }
+      },
     )

--- a/modules/fs/src/test/scala/graviton/fs/FileSystemBlobStoreSpec.scala
+++ b/modules/fs/src/test/scala/graviton/fs/FileSystemBlobStoreSpec.scala
@@ -12,40 +12,40 @@ object FileSystemBlobStoreSpec extends ZIOSpecDefault:
   def spec = suite("FileSystemBlobStoreSpec")(
     test("write, read, delete round trip") {
       for
-        tmp <- ZIO.attempt(Files.createTempDirectory("fs-store"))
-        store <- FileSystemBlobStore.make(tmp)
-        data = Chunk.fromArray("hello".getBytes)
-        hash <- Hashing.compute(
-          Bytes(ZStream.fromChunk(data)),
-          HashAlgorithm.SHA256
-        )
-        digest = hash.assume[MinLength[16] & MaxLength[64]]
-        sizeR = data.length.assume[Positive]
-        key = BlockKey(Hash(digest, HashAlgorithm.SHA256), sizeR)
-        _ <- store.write(key, Bytes(ZStream.fromChunk(data)))
-        read <- store.read(key).someOrFailException.flatMap(_.runCollect)
-        _ <- assertTrue(read == data)
+        tmp     <- ZIO.attempt(Files.createTempDirectory("fs-store"))
+        store   <- FileSystemBlobStore.make(tmp)
+        data     = Chunk.fromArray("hello".getBytes)
+        hash    <- Hashing.compute(
+                     Bytes(ZStream.fromChunk(data)),
+                     HashAlgorithm.SHA256,
+                   )
+        digest   = hash.assume[MinLength[16] & MaxLength[64]]
+        sizeR    = data.length.assume[Positive]
+        key      = BlockKey(Hash(digest, HashAlgorithm.SHA256), sizeR)
+        _       <- store.write(key, Bytes(ZStream.fromChunk(data)))
+        read    <- store.read(key).someOrFailException.flatMap(_.runCollect)
+        _       <- assertTrue(read == data)
         deleted <- store.delete(key)
-        _ <- assertTrue(deleted)
+        _       <- assertTrue(deleted)
       yield assertCompletes
     },
     test("partial read") {
       for
-        tmp <- ZIO.attempt(Files.createTempDirectory("fs-store"))
+        tmp   <- ZIO.attempt(Files.createTempDirectory("fs-store"))
         store <- FileSystemBlobStore.make(tmp)
-        data = Chunk.fromArray("hello".getBytes)
-        hash <- Hashing.compute(
-          Bytes(ZStream.fromChunk(data)),
-          HashAlgorithm.SHA256
-        )
+        data   = Chunk.fromArray("hello".getBytes)
+        hash  <- Hashing.compute(
+                   Bytes(ZStream.fromChunk(data)),
+                   HashAlgorithm.SHA256,
+                 )
         digest = hash.assume[MinLength[16] & MaxLength[64]]
-        sizeR = data.length.assume[Positive]
-        key = BlockKey(Hash(digest, HashAlgorithm.SHA256), sizeR)
-        _ <- store.write(key, Bytes(ZStream.fromChunk(data)))
-        read <- store
-          .read(key, Some(ByteRange(1, 4)))
-          .someOrFailException
-          .flatMap(_.runCollect)
+        sizeR  = data.length.assume[Positive]
+        key    = BlockKey(Hash(digest, HashAlgorithm.SHA256), sizeR)
+        _     <- store.write(key, Bytes(ZStream.fromChunk(data)))
+        read  <- store
+                   .read(key, Some(ByteRange(1, 4)))
+                   .someOrFailException
+                   .flatMap(_.runCollect)
       yield assertTrue(new String(read.toArray) == "ell")
-    }
+    },
   )

--- a/modules/fs/src/test/scala/graviton/fs/RocksDBCacheStoreSpec.scala
+++ b/modules/fs/src/test/scala/graviton/fs/RocksDBCacheStoreSpec.scala
@@ -22,38 +22,38 @@ object RocksDBCacheStoreSpec extends ZIOSpecDefault:
     suite("RocksDBCacheStore")(
       test("caches downloads when enabled") {
         for
-          dir <- ZIO.attempt(Files.createTempDirectory("rocks-cache-test"))
-          store <- RocksDBCacheStore.make(dir)
-          ref <- Ref.make(0)
-          data = "hello".getBytes.toIndexedSeq
+          dir       <- ZIO.attempt(Files.createTempDirectory("rocks-cache-test"))
+          store     <- RocksDBCacheStore.make(dir)
+          ref       <- Ref.make(0)
+          data       = "hello".getBytes.toIndexedSeq
           hashBytes <- Hashing.compute(
-            Bytes(ZStream.fromIterable(data)),
-            HashAlgorithm.SHA256
-          )
-          digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
-          hash = Hash(digest, HashAlgorithm.SHA256)
-          remote = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
-          _ <- store.fetch(hash, remote, useCache = true)
-          _ <- store.fetch(hash, remote, useCache = true)
-          calls <- ref.get
+                         Bytes(ZStream.fromIterable(data)),
+                         HashAlgorithm.SHA256,
+                       )
+          digest     = hashBytes.assume[MinLength[16] & MaxLength[64]]
+          hash       = Hash(digest, HashAlgorithm.SHA256)
+          remote     = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
+          _         <- store.fetch(hash, remote, useCache = true)
+          _         <- store.fetch(hash, remote, useCache = true)
+          calls     <- ref.get
         yield assertTrue(calls == 1)
       },
       test("bypasses cache when disabled") {
         for
-          dir <- ZIO.attempt(Files.createTempDirectory("rocks-cache-test"))
-          store <- RocksDBCacheStore.make(dir)
-          ref <- Ref.make(0)
-          data = "hello".getBytes.toIndexedSeq
+          dir       <- ZIO.attempt(Files.createTempDirectory("rocks-cache-test"))
+          store     <- RocksDBCacheStore.make(dir)
+          ref       <- Ref.make(0)
+          data       = "hello".getBytes.toIndexedSeq
           hashBytes <- Hashing.compute(
-            Bytes(ZStream.fromIterable(data)),
-            HashAlgorithm.SHA256
-          )
-          digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
-          hash = Hash(digest, HashAlgorithm.SHA256)
-          remote = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
-          _ <- store.fetch(hash, remote, useCache = false)
-          _ <- store.fetch(hash, remote, useCache = false)
-          calls <- ref.get
+                         Bytes(ZStream.fromIterable(data)),
+                         HashAlgorithm.SHA256,
+                       )
+          digest     = hashBytes.assume[MinLength[16] & MaxLength[64]]
+          hash       = Hash(digest, HashAlgorithm.SHA256)
+          remote     = ref.updateAndGet(_ + 1).as(Bytes(ZStream.fromIterable(data)))
+          _         <- store.fetch(hash, remote, useCache = false)
+          _         <- store.fetch(hash, remote, useCache = false)
+          calls     <- ref.get
         yield assertTrue(calls == 2)
       },
       test("caches downloads from external service") {
@@ -66,32 +66,32 @@ object RocksDBCacheStoreSpec extends ZIOSpecDefault:
         }
         val release = (c: GenericContainer[?]) => ZIO.attempt(c.stop()).ignore
         ZIO.acquireRelease(acquire)(release).flatMap { c =>
-          val port = c.getMappedPort(5678)
-          val host = c.getHost
+          val port                         = c.getMappedPort(5678)
+          val host                         = c.getHost
           def fetchOnce: Task[Array[Byte]] =
             ZIO.attemptBlockingIO {
               val url = java.net.URI.create(s"http://$host:$port/").toURL
-              val in = url.openStream()
+              val in  = url.openStream()
               try in.readAllBytes()
               finally in.close()
             }
           for
-            dir <- ZIO.attempt(Files.createTempDirectory("rocks-http-test"))
-            arr0 <- fetchOnce
+            dir       <- ZIO.attempt(Files.createTempDirectory("rocks-http-test"))
+            arr0      <- fetchOnce
             hashBytes <- Hashing.compute(
-              Bytes(ZStream.fromIterable(arr0)),
-              HashAlgorithm.SHA256
-            )
-            digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
-            hash = Hash(digest, HashAlgorithm.SHA256)
-            ref <- Ref.make(0)
-            remote = ref.updateAndGet(_ + 1) *> fetchOnce
-              .map(arr => Bytes(ZStream.fromIterable(arr)))
-            store <- RocksDBCacheStore.make(dir)
-            _ <- store.fetch(hash, remote, useCache = true)
-            _ <- store.fetch(hash, remote, useCache = true)
-            calls <- ref.get
+                           Bytes(ZStream.fromIterable(arr0)),
+                           HashAlgorithm.SHA256,
+                         )
+            digest     = hashBytes.assume[MinLength[16] & MaxLength[64]]
+            hash       = Hash(digest, HashAlgorithm.SHA256)
+            ref       <- Ref.make(0)
+            remote     = ref.updateAndGet(_ + 1) *> fetchOnce
+                           .map(arr => Bytes(ZStream.fromIterable(arr)))
+            store     <- RocksDBCacheStore.make(dir)
+            _         <- store.fetch(hash, remote, useCache = true)
+            _         <- store.fetch(hash, remote, useCache = true)
+            calls     <- ref.get
           yield assertTrue(calls == 1)
         }
-      } @@ TestAspect.ifEnvSet("TESTCONTAINERS")
+      } @@ TestAspect.ifEnvSet("TESTCONTAINERS"),
     )

--- a/modules/metrics/src/main/scala/graviton/metrics/Metrics.scala
+++ b/modules/metrics/src/main/scala/graviton/metrics/Metrics.scala
@@ -2,30 +2,26 @@ package graviton.metrics
 
 import zio.*
 import zio.metrics.*
-import zio.metrics.connectors.prometheus.{
-  PrometheusPublisher,
-  prometheusLayer,
-  publisherLayer
-}
+import zio.metrics.connectors.prometheus.{PrometheusPublisher, prometheusLayer, publisherLayer}
 import zio.metrics.connectors.MetricsConfig
 import java.time.Duration
 
 object Metrics:
-  val putCount: Metric.Counter[Int] = Metric.counterInt("graviton_put_total")
-  val putLatency = Metric.timer(
+  val putCount: Metric.Counter[Int]    = Metric.counterInt("graviton_put_total")
+  val putLatency                       = Metric.timer(
     "graviton_put_latency_seconds",
-    java.time.temporal.ChronoUnit.SECONDS
+    java.time.temporal.ChronoUnit.SECONDS,
   )
-  val getCount: Metric.Counter[Int] = Metric.counterInt("graviton_get_total")
-  val getLatency = Metric.timer(
+  val getCount: Metric.Counter[Int]    = Metric.counterInt("graviton_get_total")
+  val getLatency                       = Metric.timer(
     "graviton_get_latency_seconds",
-    java.time.temporal.ChronoUnit.SECONDS
+    java.time.temporal.ChronoUnit.SECONDS,
   )
   val deleteCount: Metric.Counter[Int] =
     Metric.counterInt("graviton_delete_total")
-  val deleteLatency = Metric.timer(
+  val deleteLatency                    = Metric.timer(
     "graviton_delete_latency_seconds",
-    java.time.temporal.ChronoUnit.SECONDS
+    java.time.temporal.ChronoUnit.SECONDS,
   )
 
   val prometheus: ULayer[PrometheusPublisher] = publisherLayer

--- a/modules/metrics/src/main/scala/graviton/metrics/MetricsBinaryStore.scala
+++ b/modules/metrics/src/main/scala/graviton/metrics/MetricsBinaryStore.scala
@@ -6,43 +6,42 @@ import zio.*
 import zio.stream.*
 import Metrics.*
 
-final case class MetricsBinaryStore(underlying: BinaryStore)
-    extends BinaryStore:
+final case class MetricsBinaryStore(underlying: BinaryStore) extends BinaryStore:
   override def put(
-      attrs: BinaryAttributes,
-      chunkSize: Int
+    attrs: BinaryAttributes,
+    chunkSize: Int,
   ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
     ZSink.unwrapScoped {
       Clock.nanoTime.map { start =>
         underlying.put(attrs, chunkSize).mapZIO { id =>
           for
             end <- Clock.nanoTime
-            _ <- putCount.increment
-            _ <- putLatency.update(Duration.fromNanos(end - start))
+            _   <- putCount.increment
+            _   <- putLatency.update(Duration.fromNanos(end - start))
           yield id
         }
       }
     }
 
   override def get(
-      id: BinaryId,
-      range: Option[ByteRange]
+    id: BinaryId,
+    range: Option[ByteRange],
   ): IO[Throwable, Option[graviton.Bytes]] =
     for
       start <- Clock.nanoTime
-      res <- underlying.get(id, range)
-      end <- Clock.nanoTime
-      _ <- getCount.increment
-      _ <- getLatency.update(Duration.fromNanos(end - start))
+      res   <- underlying.get(id, range)
+      end   <- Clock.nanoTime
+      _     <- getCount.increment
+      _     <- getLatency.update(Duration.fromNanos(end - start))
     yield res
 
   override def delete(id: BinaryId): IO[Throwable, Boolean] =
     for
       start <- Clock.nanoTime
-      res <- underlying.delete(id)
-      end <- Clock.nanoTime
-      _ <- deleteCount.increment
-      _ <- deleteLatency.update(Duration.fromNanos(end - start))
+      res   <- underlying.delete(id)
+      end   <- Clock.nanoTime
+      _     <- deleteCount.increment
+      _     <- deleteLatency.update(Duration.fromNanos(end - start))
     yield res
 
   override def exists(id: BinaryId): IO[Throwable, Boolean] =

--- a/modules/metrics/src/test/scala/graviton/metrics/MetricsBinaryStoreSpec.scala
+++ b/modules/metrics/src/test/scala/graviton/metrics/MetricsBinaryStoreSpec.scala
@@ -9,13 +9,13 @@ import zio.test.*
 object MetricsBinaryStoreSpec extends ZIOSpecDefault:
   private val stub = new BinaryStore:
     def put(
-        attrs: BinaryAttributes,
-        chunkSize: Int
+      attrs: BinaryAttributes,
+      chunkSize: Int,
     ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
       ZSink.succeed(BinaryId("id"))
     def get(
-        id: BinaryId,
-        range: Option[ByteRange]
+      id: BinaryId,
+      range: Option[ByteRange],
     ): IO[Throwable, Option[graviton.Bytes]] =
       ZIO.succeed(None)
     def delete(id: BinaryId): IO[Throwable, Boolean] =
@@ -28,16 +28,16 @@ object MetricsBinaryStoreSpec extends ZIOSpecDefault:
       val store = MetricsBinaryStore(stub)
       for
         before <- Metrics.getCount.value.map(_.count)
-        _ <- store.get(BinaryId("a"), None)
-        after <- Metrics.getCount.value.map(_.count)
+        _      <- store.get(BinaryId("a"), None)
+        after  <- Metrics.getCount.value.map(_.count)
       yield assertTrue(after == before + 1)
     },
     test("records delete count") {
       val store = MetricsBinaryStore(stub)
       for
         before <- Metrics.deleteCount.value.map(_.count)
-        _ <- store.delete(BinaryId("a"))
-        after <- Metrics.deleteCount.value.map(_.count)
+        _      <- store.delete(BinaryId("a"))
+        after  <- Metrics.deleteCount.value.map(_.count)
       yield assertTrue(after == before + 1)
-    }
+    },
   )

--- a/modules/pg/src/main/scala/graviton/pg/Canon.scala
+++ b/modules/pg/src/main/scala/graviton/pg/Canon.scala
@@ -2,7 +2,7 @@ package graviton.pg
 
 import zio.Chunk
 import zio.schema.DynamicValue
-import zio.schema.codec.JsonCodec.{ExplicitConfig}
+import zio.schema.codec.JsonCodec.ExplicitConfig
 import zio.schema.codec.JsonCodec
 
 object Canon:
@@ -17,14 +17,14 @@ object Canon:
     codec.encode(dv)
 
   def storeKey(
-      implId: String,
-      dvCanon: Chunk[Byte],
-      buildFp: Chunk[Byte],
-      H: Chunk[Byte] => Chunk[Byte]
+    implId: String,
+    dvCanon: Chunk[Byte],
+    buildFp: Chunk[Byte],
+    H: Chunk[Byte] => Chunk[Byte],
   ): StoreKey =
-    val sep = Chunk.single(0.toByte)
+    val sep      = Chunk.single(0.toByte)
     val material = Chunk.fromArray(
       implId.getBytes("UTF-8")
     ) ++ sep ++ dvCanon ++ sep ++ buildFp
-    
+
     StoreKey.applyUnsafe(H(material))

--- a/modules/pg/src/main/scala/graviton/pg/Repos.scala
+++ b/modules/pg/src/main/scala/graviton/pg/Repos.scala
@@ -11,105 +11,110 @@ import io.github.iltotore.iron.constraint.all.*
 import zio.prelude.*
 import zio.prelude.classic.Monoid
 
-
 opaque type Max[A] <: A = A
 object Max:
-  def apply[A](a: A): Max[A] = a
+  def apply[A](a: A): Max[A]              = a
   def unapply(a: Max[Long]): Option[Long] = Some(a)
   given [A](using PartialOrd[A], Identity[A]): Monoid[Max[A]] with
-    def identity: Max[A] = Max(Identity[A].identity)
+    def identity: Max[A]                            = Max(Identity[A].identity)
     def combine(a: => Max[A], b: => Max[A]): Max[A] = a.maximum(b)
-  
-  extension [A](a: Max[A]) 
-    def value: A = a
-    def maximum(other: Max[A])(using PartialOrd[A]): Max[A] = 
+
+  extension [A](a: Max[A])
+    def value: A                                            = a
+    def maximum(other: Max[A])(using PartialOrd[A]): Max[A] =
       if a > other then a else other
 
 type BlockInsert = (key: BlockKey, offset: NonNegLong, length: PosLong)
 
 case class Cursor(queryId: Option[UUID], offset: Long, total: Option[Max[Long]], pageSize: Long):
-  def isLast: Boolean = total.exists(_ <= offset) || pageSize == 0
+  def isLast: Boolean                  = total.exists(_ <= offset) || pageSize == 0
   def next(lastPageSize: Long): Cursor = Cursor(
-    queryId, 
-    offset + lastPageSize, 
+    queryId,
+    offset + lastPageSize,
     total.filter(_ > offset + lastPageSize),
-    pageSize
+    pageSize,
   )
-  def combine(other: Cursor): Cursor = if queryId == other.queryId then 
-    other.next(other.offset)
+  def combine(other: Cursor): Cursor   = if queryId == other.queryId then other.next(other.offset)
   else this
 
-  def withTotal(newTotal: Max[Long]): Cursor = 
+  def withTotal(newTotal: Max[Long]): Cursor =
     copy(total = total.map(_.maximum(newTotal)).orElse(Some(newTotal)))
 
   def withQueryId(newQueryId: Option[UUID]): Cursor = copy(queryId = newQueryId)
 
-
 object Cursor:
   val emptyQueryId = UUID.fromString("00000000-0000-0000-0000-000000000000")
   given Monoid[Cursor] with
-    def identity: Cursor = Cursor(None, 0L, None, 0L)
-    def combine(a: => Cursor, b: => Cursor): Cursor = 
-      if a.queryId == b.queryId | 
-      b.queryId.contains(emptyQueryId) | 
-      a.queryId.contains(emptyQueryId) 
-      then a.next(b.offset).withQueryId(
-        Seq(a.queryId, b.queryId)
-        .flatten
-        .filter(_ != emptyQueryId)
-        .headOption
-      )
+    def identity: Cursor                            = Cursor(None, 0L, None, 0L)
+    def combine(a: => Cursor, b: => Cursor): Cursor =
+      if a.queryId == b.queryId |
+          b.queryId.contains(emptyQueryId) |
+          a.queryId.contains(emptyQueryId)
+      then
+        a.next(b.offset)
+          .withQueryId(
+            Seq(a.queryId, b.queryId).flatten
+              .filter(_ != emptyQueryId)
+              .headOption
+          )
       else b.total.fold(a)(a.withTotal).next(b.offset)
 
   case class Patch(offset: Long, total: Option[Max[Long]])
 
   val differ: Differ[Cursor, Patch] = new Differ[Cursor, Patch] {
 
-
-      /**
-       * Combines two patches to produce a new patch that describes the updates of
-       * the first patch and then the updates of the second patch. The combine
-       * operation should be associative. In addition, if the combine operation is
-       * commutative then joining multiple fibers concurrently will result in
-       * deterministic `FiberRef` values.
-       */
-      def combine(first: Patch, second: Patch): Patch = 
-        Patch(
-          first.offset + second.offset, 
-          first.total.as(first)
+    /**
+     * Combines two patches to produce a new patch that describes the updates of
+     * the first patch and then the updates of the second patch. The combine
+     * operation should be associative. In addition, if the combine operation is
+     * commutative then joining multiple fibers concurrently will result in
+     * deterministic `FiberRef` values.
+     */
+    def combine(first: Patch, second: Patch): Patch =
+      Patch(
+        first.offset + second.offset,
+        first.total
+          .as(first)
           .zipWith(second.total.as(second)) { (a, b) =>
-            (a.total.zipWith(b.total)(_ min _)).flatMap { t =>
-              Some(t).filter(_ > a.offset + second.offset)
-            }.orElse(first.total.orElse(second.total))
-          }.flatten
-        )
+            (a.total
+              .zipWith(b.total)(_ min _))
+              .flatMap { t =>
+                Some(t).filter(_ > a.offset + second.offset)
+              }
+              .orElse(first.total.orElse(second.total))
+          }
+          .flatten,
+      )
 
-      /**
-       * Constructs a patch describing the updates to a value from an old value and
-       * a new value.
-       */
-      def diff(oldValue: Cursor, newValue: Cursor): Patch = 
-        Patch(newValue.offset - oldValue.offset, newValue.total.filter(_ > newValue.offset))
+    /**
+     * Constructs a patch describing the updates to a value from an old value and
+     * a new value.
+     */
+    def diff(oldValue: Cursor, newValue: Cursor): Patch =
+      Patch(newValue.offset - oldValue.offset, newValue.total.filter(_ > newValue.offset))
 
-      /**
-       * An empty patch that describes no changes.
-       */
-      def empty: Patch = Patch(0L, None)
+    /**
+     * An empty patch that describes no changes.
+     */
+    def empty: Patch = Patch(0L, None)
 
-      /**
-       * Applies a patch to an old value to produce a new value that is equal to the
-       * old value with the updates described by the patch.
-       */
-      def patch(patch: Patch)(oldValue: Cursor): Cursor =
-        oldValue
+    /**
+     * Applies a patch to an old value to produce a new value that is equal to the
+     * old value with the updates described by the patch.
+     */
+    def patch(patch: Patch)(oldValue: Cursor): Cursor =
+      oldValue
         .next(patch.offset)
         .withTotal(patch.total.getOrElse(oldValue.total.getOrElse(Max(0L))))
   }
 
-  private [pg] object ref:
-    val cursorRef: FiberRef[Cursor] = Unsafe.unsafe { implicit u => 
+  private[pg] object ref:
+    val cursorRef: FiberRef[Cursor] = Unsafe.unsafe { implicit u =>
       FiberRef.unsafe.makePatch(
-        initial, Cursor.differ, Patch(0L, None), (a, b) => (a.combine(b))
+        initial,
+        Cursor.differ,
+        Patch(0L, None),
+        (a, b) => (a.combine(b)),
       )
     }
 
@@ -121,7 +126,7 @@ trait BlobStoreRepo:
   def listActive(cursor: Option[Cursor] = None): ZStream[Any, Throwable, BlobStoreRow]
 
 final class BlobStoreRepoLive(xa: TransactorZIO) extends BlobStoreRepo:
-  
+
   def upsert(row: BlobStoreRow): Task[Int] =
     xa.transact {
       sql"""
@@ -143,18 +148,21 @@ final class BlobStoreRepoLive(xa: TransactorZIO) extends BlobStoreRepo:
 
   def listActive(cursor: Option[Cursor] = None): ZStream[Any, Throwable, BlobStoreRow] =
     ZStream.unwrapScoped {
-      for 
-        total <- Ref.make(cursor.getOrElse(Cursor.initial))
+      for
+        total       <- Ref.make(cursor.getOrElse(Cursor.initial))
         firstCursor <- total.get
-        limit = 
-          cursor.flatMap(_.total).getOrElse(Max(Long.MaxValue)).value
-          .min(cursor.map(_.offset).getOrElse(firstCursor.pageSize))
-          .min(firstCursor.pageSize)
-        rows = ZStream.paginateChunkZIO(0) { offset =>
-          for {
-            totalNow <- total.get
-            rows <- xa.transact {
-            val rows = sql"""
+        limit        =
+          cursor
+            .flatMap(_.total)
+            .getOrElse(Max(Long.MaxValue))
+            .value
+            .min(cursor.map(_.offset).getOrElse(firstCursor.pageSize))
+            .min(firstCursor.pageSize)
+        rows         = ZStream.paginateChunkZIO(0) { offset =>
+                         for {
+                           totalNow <- total.get
+                           rows     <- xa.transact {
+                                         val rows = sql"""
               SELECT count(*) as total, key, impl_id, build_fp, dv_schema_urn, dv_canonical_bin, dv_json_preview, status, version
               FROM blob_store WHERE status = ${StoreStatus.Active}
               ORDER BY updated_at DESC
@@ -162,23 +170,24 @@ final class BlobStoreRepoLive(xa: TransactorZIO) extends BlobStoreRepo:
               OFFSET $offset
             """.query[(Long, BlobStoreRow)].run()
 
-            val newTotal = rows.headOption.map(_._1).orElse(totalNow.total).getOrElse(0L)
-            val newOffset = offset + rows.size
+                                         val newTotal  = rows.headOption.map(_._1).orElse(totalNow.total).getOrElse(0L)
+                                         val newOffset = offset + rows.size
 
-            Chunk.fromIterable(rows.view.map(_._2)) -> (newTotal, newOffset)
+                                         Chunk.fromIterable(rows.view.map(_._2)) -> (newTotal, newOffset)
 
-          }.flatMap {
-            case (rows, (newTotal, newOffset)) => 
-              for 
-                current <- total.get
-                _ <- total.set(current.withTotal(Max(newTotal)).next(newOffset))
-              yield (rows, Some(newOffset).filter(_ => newOffset < limit && current.total.getOrElse(Max(0L)) < Max(newTotal)))
-            }
-          } yield rows    
-        }
+                                       }.flatMap { case (rows, (newTotal, newOffset)) =>
+                                         for
+                                           current <- total.get
+                                           _       <- total.set(current.withTotal(Max(newTotal)).next(newOffset))
+                                         yield (
+                                           rows,
+                                           Some(newOffset).filter(_ => newOffset < limit && current.total.getOrElse(Max(0L)) < Max(newTotal)),
+                                         )
+                                       }
+                         } yield rows
+                       }
       yield rows
     }
-
 
 object BlobStoreRepoLive:
   val layer: ZLayer[TransactorZIO, Nothing, BlobStoreRepo] =
@@ -189,27 +198,27 @@ object BlobStoreRepoLive:
 trait BlockRepo:
 
   def upsertBlock(
-      key: BlockKey,
-      size: PosLong,
-      inline: Option[SmallBytes]
+    key: BlockKey,
+    size: PosLong,
+    inline: Option[SmallBytes],
   ): Task[Int]
 
   def getHead(key: BlockKey): Task[Option[(PosLong, Boolean)]]
 
   def linkLocation(
-      key: BlockKey,
-      storeKey: StoreKey,
-      uri: Option[String],
-      len: PosLong,
-      etag: Option[String],
-      storageClass: Option[String]
+    key: BlockKey,
+    storeKey: StoreKey,
+    uri: Option[String],
+    len: PosLong,
+    etag: Option[String],
+    storageClass: Option[String],
   ): Task[Int]
 
 final class BlockRepoLive(xa: TransactorZIO) extends BlockRepo:
   def upsertBlock(
-      key: BlockKey,
-      size: PosLong,
-      inline: Option[SmallBytes]
+    key: BlockKey,
+    size: PosLong,
+    inline: Option[SmallBytes],
   ): Task[Int] =
     xa.transact {
       sql"""
@@ -230,12 +239,12 @@ final class BlockRepoLive(xa: TransactorZIO) extends BlockRepo:
     }
 
   def linkLocation(
-      key: BlockKey,
-      storeKey: StoreKey,
-      uri: Option[String],
-      len: PosLong,
-      etag: Option[String],
-      storageClass: Option[String]
+    key: BlockKey,
+    storeKey: StoreKey,
+    uri: Option[String],
+    len: PosLong,
+    etag: Option[String],
+    storageClass: Option[String],
   ): Task[Int] =
     xa.transact {
       sql"""
@@ -261,7 +270,7 @@ trait FileRepo:
   def upsertFile(key: FileKey): Task[UUID]
 
   def putFileBlocks(
-      fileId: UUID
+    fileId: UUID
   ): ZPipeline[Any, Throwable, BlockInsert, BlockKey]
 
   def findFileId(key: FileKey): Task[Option[UUID]]
@@ -270,36 +279,33 @@ final class FileRepoLive(xa: TransactorZIO) extends FileRepo:
   def upsertFile(key: FileKey): Task[UUID] =
     Random.nextUUID.flatMap(id =>
       xa.transact {
-      sql"""
+        sql"""
           INSERT INTO file (id, algo_id, hash, size_bytes, media_type)
           VALUES ($id, ${key.algoId}, ${key.hash}, ${key.size}, ${key.mediaType})
           ON CONFLICT (algo_id, hash, size_bytes) DO UPDATE
           SET media_type = EXCLUDED.media_type
           RETURNING id
         """.query[UUID].run().head
-      })
-        
+      }
+    )
 
   def putFileBlocks(
-      fileId: UUID
+    fileId: UUID
   ): ZPipeline[Any, Throwable, BlockInsert, BlockKey] =
-    ZPipeline.fromFunction(
-      (s: ZStream[Any, Throwable, BlockInsert]) => 
-      s.zipWithIndex.mapChunksZIO {
-        case chunk =>
-            chunk.mapZIO { case ((bk, offset, len), idx) =>
-              xa.transact {
-                sql"""
+    ZPipeline.fromFunction((s: ZStream[Any, Throwable, BlockInsert]) =>
+      s.zipWithIndex.mapChunksZIO { case chunk =>
+        chunk
+          .mapZIO { case ((bk, offset, len), idx) =>
+            xa.transact {
+              sql"""
                   INSERT INTO file_block (file_id, seq, block_algo_id, block_hash, offset_bytes, length_bytes)
                   VALUES ($fileId, $idx, ${bk.algoId}, ${bk.hash}, $offset, $len)
                 """.returning[BlockKey].run()
-              }.map(Chunk.fromIterable)
-          }.map(_.flatten)
-        }
+            }.map(Chunk.fromIterable)
+          }
+          .map(_.flatten)
+      }
     )
-    
-
-    
 
   def findFileId(key: FileKey): Task[Option[UUID]] =
     xa.transact {

--- a/modules/pg/src/main/scala/graviton/pg/model.scala
+++ b/modules/pg/src/main/scala/graviton/pg/model.scala
@@ -14,50 +14,43 @@ import zio.schema.DynamicValue
 trait RefinedTypeExt[A, C] extends RefinedType[A, C]:
 
   given (using d: DbCodec[A]): DbCodec[T] = d.biMap(applyUnsafe(_), _.value)
-  given (using s: Schema[A]): Schema[T] = s
-  .annotate(rtc.message)
-  .transformOrFail(either(_), v => Right(v.value))
+  given (using s: Schema[A]): Schema[T]   = s
+    .annotate(rtc.message)
+    .transformOrFail(either(_), v => Right(v.value))
 
 end RefinedTypeExt
 
 trait RefinedSubTypeExt[A, C] extends RefinedSubtype[A, C]:
 
   given (using d: DbCodec[A]): DbCodec[T] = d.biMap(applyUnsafe(_), _.value)
-  given (using s: Schema[A]): Schema[T] = s
-  .annotate(rtc.message)
-  .transformOrFail(either(_), v => Right(v.value))
+  given (using s: Schema[A]): Schema[T]   = s
+    .annotate(rtc.message)
+    .transformOrFail(either(_), v => Right(v.value))
 
 end RefinedSubTypeExt
 
-opaque type JsonObject = 
-  DynamicValue.Record | 
-  DynamicValue.Dictionary | 
-  DynamicValue.DynamicAst | 
-  DynamicValue.Tuple |
-  DynamicValue.Enumeration
+opaque type JsonObject =
+  DynamicValue.Record | DynamicValue.Dictionary | DynamicValue.DynamicAst | DynamicValue.Tuple | DynamicValue.Enumeration
 
 // given DbCodec[JsonObject] = new JsonBDbCodec[JsonObject]:
 //   import zio.schema.codec.BinaryCodecs
 //   import zio.constraintless.TypeList.{::, End}
 
-//   val enumSchema: Schema.EnumN[DynamicValue, CaseSet] = 
+//   val enumSchema: Schema.EnumN[DynamicValue, CaseSet] =
 //     DynamicValue.schema.asInstanceOf[Schema.EnumN[DynamicValue, CaseSet]]
 
 //   val cases = enumSchema.cases.toMap
 
 //   given Schema[DynamicValue.Record] =
-//     DynamicValue.schema match 
+//     DynamicValue.schema match
 //       case s @ Schema.EnumN(_, cases, _) =>
-//         cases.toMap.get(Name) match 
-//           casesMap.get(Name) match 
+//         cases.toMap.get(Name) match
+//           casesMap.get(Name) match
 //             case Some(schema) => schema
 //             case None => throw new IllegalArgumentException(s"Schema for $Name not found")
-        
-//         given Schema[DynamicValue.Record] = 
 
+//         given Schema[DynamicValue.Record] =
 
-        
-    
 //     Schema.CaseClass2[TypeId, Chunk[(String, DynamicValue)], DynamicValue.Record](
 //       TypeId.parse("zio.schema.DynamicValue.Record"),
 //       Schema.Field("id", Schema[TypeId], get0 = record => record.id, set0 = (record, id) => record.copy(id = id)),
@@ -75,7 +68,6 @@ opaque type JsonObject =
 //     DynamicValue.Record :: DynamicValue.Dictionary :: DynamicValue.DynamicAst :: DynamicValue.Tuple :: DynamicValue.Enumeration :: End
 //   ]
 
-
 //   def encode(a: JsonObject): String = a.toJson
 //   def decode(json: String): JsonObject =
 //     json
@@ -87,13 +79,13 @@ type ExactLength[N <: Int] = Length[StrictEqual[N]]
 
 // ---- Refined byte types
 
-type HashBytes = Chunk[Byte] :| (MinLength[16] & MaxLength[64])
+type HashBytes  = Chunk[Byte] :| (MinLength[16] & MaxLength[64])
 type SmallBytes = Chunk[Byte] :| MaxLength[1048576]
 
 type StoreKey = StoreKey.T
 object StoreKey extends RefinedSubTypeExt[Chunk[Byte], ExactLength[32]]
 
-type PosLong = Long :| Positive
+type PosLong    = Long :| Positive
 type NonNegLong = Long :| Not[Negative]
 
 object Algo:
@@ -115,21 +107,21 @@ enum LocationStatus derives DbCodec:
 final case class BlockKey(algoId: Short, hash: HashBytes) derives DbCodec
 
 final case class FileKey(
-    algoId: Short,
-    hash: HashBytes,
-    size: PosLong,
-    mediaType: Option[String]
+  algoId: Short,
+  hash: HashBytes,
+  size: PosLong,
+  mediaType: Option[String],
 ) derives DbCodec
 
 final case class BlobStoreRow(
-    key: StoreKey,
-    implId: String,
-    buildFp: Chunk[Byte],
-    dvSchemaUrn: String,
-    dvCanonical: Chunk[Byte],
-    dvJsonPreview: Option[Json],
-    status: StoreStatus,
-    version: Long
+  key: StoreKey,
+  implId: String,
+  buildFp: Chunk[Byte],
+  dvSchemaUrn: String,
+  dvCanonical: Chunk[Byte],
+  dvJsonPreview: Option[Json],
+  status: StoreStatus,
+  version: Long,
 ) derives DbCodec
 
 // ---- DbCodec instances for refined types
@@ -144,7 +136,7 @@ given DbCodec[java.util.UUID] =
   DbCodec[String].biMap(java.util.UUID.fromString, _.toString)
 
 given JsonBDbCodec[Json] with
-  def encode(a: Json): String = 
+  def encode(a: Json): String    =
     a.toJson
   def decode(json: String): Json =
     json
@@ -157,17 +149,12 @@ object DynamicValueSchema:
   import TypeList.{::, End}
   import zio.schema.TypeId
 
-  type ObjectTypes = 
-    DynamicValue.Record :: 
-      DynamicValue.Dictionary :: 
-        DynamicValue.DynamicAst :: 
-          DynamicValue.Tuple :: 
-            DynamicValue.Enumeration :: 
-              End
+  type ObjectTypes =
+    DynamicValue.Record :: DynamicValue.Dictionary :: DynamicValue.DynamicAst :: DynamicValue.Tuple :: DynamicValue.Enumeration :: End
 
   def getBuiltInTypeId[BuiltIn <: TypeList](
     instances: SchemaInstances[BuiltIn],
-    schema: Schema[?]
+    schema: Schema[?],
   ): Option[TypeId] =
     if (instances.all.contains(schema)) {
       schema match {
@@ -181,7 +168,7 @@ object DynamicValueSchema:
   // private val builtInInstances = SchemaInstances.make[ObjectTypes]
 
   // def restrictCases(schema: Schema[DynamicValue], allowed: Set[String]): Schema[DynamicValue] =
-  //   def labelOf(dv: DynamicValue): String = 
+  //   def labelOf(dv: DynamicValue): String =
   //     dv match
   //     case DynamicValue.Record      => "Record"
   //     case DynamicValue.Dictionary  => "Dictionary"

--- a/modules/pg/src/test/scala/graviton/pg/BlobStoreRepoSpec.scala
+++ b/modules/pg/src/test/scala/graviton/pg/BlobStoreRepoSpec.scala
@@ -7,15 +7,14 @@ import com.augustnagro.magnum.{DbCodec, sql}
 
 case object BlobStoreRepoSpec extends ZIOSpec[TestEnvironment & BlobStoreRepo & TransactorZIO]:
 
-  val bootstrap = 
-    ((ZLayer.fromZIO(ZIO.config[PgTestLayers.PgTestConfig]) >>> PgTestLayers.layer) >+> 
-      BlobStoreRepoLive.layer
-    ) ++ 
-    testEnvironment
+  val bootstrap =
+    ((ZLayer.fromZIO(ZIO.config[PgTestLayers.PgTestConfig]) >>> PgTestLayers.layer) >+>
+      BlobStoreRepoLive.layer) ++
+      testEnvironment
 
   private def sampleRow: BlobStoreRow =
     val key: StoreKey = StoreKey.applyUnsafe(Chunk.fill(32)(1.toByte))
-    val bytes = Chunk.fromArray(Array[Byte](1, 2, 3))
+    val bytes         = Chunk.fromArray(Array[Byte](1, 2, 3))
     BlobStoreRow(
       key,
       "fs",
@@ -24,44 +23,44 @@ case object BlobStoreRepoSpec extends ZIOSpec[TestEnvironment & BlobStoreRepo & 
       bytes,
       None,
       StoreStatus.Active,
-      0L
+      0L,
     )
 
   def spec =
     suite("BlobStoreRepo")(
       test("writes, reads, and deletes data") {
         for {
-          xa <- ZIO.service[TransactorZIO]
-          _ <- Console.printLine("Writing data")
+          xa       <- ZIO.service[TransactorZIO]
+          _        <- Console.printLine("Writing data")
           sampleRow = (
-            key = Chunk.fill(32)(1.toByte),
-            implId = "fs",
-            buildFp = "build_fp",
-            dvSchemaUrn = "dv_schema_urn",
-            dvCanonical = "dv_canonical",
-            dvJsonPreview = "dv_json_preview",
-            status = "active"
-          )
-          _ <- Console.printLine("Reading data")
-          _ <- xa.transact {
-              Console.printLine("Inserting data") *>
-              ZIO.attempt(sql"""
+                        key = Chunk.fill(32)(1.toByte),
+                        implId = "fs",
+                        buildFp = "build_fp",
+                        dvSchemaUrn = "dv_schema_urn",
+                        dvCanonical = "dv_canonical",
+                        dvJsonPreview = "dv_json_preview",
+                        status = "active",
+                      )
+          _        <- Console.printLine("Reading data")
+          _        <- xa.transact {
+                        Console.printLine("Inserting data") *>
+                          ZIO.attempt(sql"""
                 INSERT INTO blob_store (key, impl_id, build_fp, dv_schema_urn, dv_canonical_bin, dv_json_preview, status)
                 VALUES (${sampleRow.key}, ${sampleRow.implId}, ${sampleRow.buildFp}, ${sampleRow.dvSchemaUrn}, ${sampleRow.dvCanonical}, ${sampleRow.dvJsonPreview}, ${sampleRow.status})
               """.query[Int].run()) *>
-              Console.printLine("Reading data") *>
-              ZIO.attempt(sql"""
+                          Console.printLine("Reading data") *>
+                          ZIO.attempt(sql"""
                 SELECT * FROM blob_store WHERE key = ${sampleRow.key}
               """.query[BlobStoreRow].run())
-          }
+                      }
         } yield assertTrue(true)
       },
       test("upsert and fetch") {
         for
           repo <- ZIO.service[BlobStoreRepo]
-          row = sampleRow
-          _ <- repo.upsert(row)
-          got <- repo.get(row.key)
+          row   = sampleRow
+          _    <- repo.upsert(row)
+          got  <- repo.get(row.key)
         yield assertTrue(got.exists(_.implId == "fs"))
-      }
+      },
     ) @@ TestAspect.ifEnvSet("TESTCONTAINERS")

--- a/modules/pg/src/test/scala/graviton/pg/PgTestLayers.scala
+++ b/modules/pg/src/test/scala/graviton/pg/PgTestLayers.scala
@@ -25,131 +25,129 @@ object PgTestLayers:
     database: String,
     initScript: Option[Path],
     startupAttempts: Int,
-    startupTimeout: Long
+    startupTimeout: Long,
   )
   object PgTestConfig:
 
     val layer = ZLayer.fromZIO(ZIO.config[PgTestConfig])
 
-    def provider = 
-      ConfigProvider.fromMap(
-        Map(
-          "image" -> "postgres:17-alpine",
-          "username" -> "postgres",
-          "password" -> "postgres",
-          "database" -> "postgres",
-          "initScript" -> "ddl.sql",
-          "startupAttempts" -> "3",
-          "startupTimeout" -> "90"
+    def provider =
+      ConfigProvider
+        .fromMap(
+          Map(
+            "image"           -> "postgres:17-alpine",
+            "username"        -> "postgres",
+            "password"        -> "postgres",
+            "database"        -> "postgres",
+            "initScript"      -> "ddl.sql",
+            "startupAttempts" -> "3",
+            "startupTimeout"  -> "90",
+          )
         )
-      )
-      .orElse(ConfigProvider.envProvider)
-      .orElse(ConfigProvider.propsProvider)
-      .nested("pg")
-    
+        .orElse(ConfigProvider.envProvider)
+        .orElse(ConfigProvider.propsProvider)
+        .nested("pg")
 
     given config: Config[PgTestConfig] =
 
-      val image = Config.string("image").withDefault("postgres")
-      val tag = Config.string("tag").withDefault("17-alpine")
-      val registry = Config.string("registry").optional
-      val repository = Config.string("repository").optional
-      val username = Config.string("username").withDefault("postgres")
-      val password = Config.string("password").withDefault("postgres")
-      val database = Config.string("database").withDefault("postgres")
-      val initScript = Config.string("initScript").withDefault("ddl.sql").map(Path.of(_)).optional
+      val image           = Config.string("image").withDefault("postgres")
+      val tag             = Config.string("tag").withDefault("17-alpine")
+      val registry        = Config.string("registry").optional
+      val repository      = Config.string("repository").optional
+      val username        = Config.string("username").withDefault("postgres")
+      val password        = Config.string("password").withDefault("postgres")
+      val database        = Config.string("database").withDefault("postgres")
+      val initScript      = Config.string("initScript").withDefault("ddl.sql").map(Path.of(_)).optional
       val startupAttempts = Config.int("startupAttempts").withDefault(3)
-      val startupTimeout = Config.long("startupTimeout").withDefault(90L)
+      val startupTimeout  = Config.long("startupTimeout").withDefault(90L)
 
       (image ++ tag ++ registry ++ repository ++ username ++ password ++ database ++ initScript ++ startupAttempts ++ startupTimeout).map:
         case (image, tag, registry, repository, username, password, database, initScript, startupAttempts, startupTimeout) =>
           PgTestConfig(
-            image = image, 
+            image = image,
             tag = tag,
             registry = registry,
             repository = repository,
-            username = username, 
-            password = password, 
-            database = database, 
-            initScript = initScript, 
-            startupAttempts = startupAttempts, 
-            startupTimeout = startupTimeout
+            username = username,
+            password = password,
+            database = database,
+            initScript = initScript,
+            startupAttempts = startupAttempts,
+            startupTimeout = startupTimeout,
           )
 
     end config
-
 
   val containerProvider: ZLayer[Any, Throwable, PostgreSQLContainerProvider] =
     ZLayer.succeed(new PostgreSQLContainerProvider())
 
   val getImageName: ZPure[Nothing, Unit, DockerImageName, PgTestConfig, Throwable, DockerImageName] =
-    for 
+    for
       config <- State.service[Unit, PgTestConfig]
-      imgN <- ZPure.attempt(DockerImageName.parse(config.image))
-      _ <- State.set(imgN)
-      _ <- State.update((_: DockerImageName).withTag(config.tag))
-      _ <- State.update((d: DockerImageName) => config.registry.fold(d)(d.withRegistry))
-      _ <- State.update((d: DockerImageName) => config.repository.fold(d)(d.withRepository))
-      img <- State.get[DockerImageName]
+      imgN   <- ZPure.attempt(DockerImageName.parse(config.image))
+      _      <- State.set(imgN)
+      _      <- State.update((_: DockerImageName).withTag(config.tag))
+      _      <- State.update((d: DockerImageName) => config.registry.fold(d)(d.withRegistry))
+      _      <- State.update((d: DockerImageName) => config.repository.fold(d)(d.withRepository))
+      img    <- State.get[DockerImageName]
     yield img
 
   private def mkContainer: ZLayer[PgTestConfig, Throwable, PostgreSQLContainer[?]] =
     ZLayer.scoped:
-      for 
-        imgN <- getImageName.toZIO
-        config <- ZIO.service[PgTestConfig]
+      for
+        imgN      <- getImageName.toZIO
+        config    <- ZIO.service[PgTestConfig]
         container <- ZIO.acquireRelease(
-          ZIO.attempt {
-            val c = PostgreSQLContainer(imgN)
-            c.withUsername(config.username)
-            c.withPassword(config.password)
-            c.withDatabaseName(config.database)
-            c.withInitScript(config.initScript.toString)
-            c.withStartupAttempts(config.startupAttempts)
-            c.withStartupTimeout(Duration.ofSeconds(config.startupTimeout))
-            c.withReuse(true)
-            c.waitingFor(Wait.forListeningPort().withStartupTimeout(config.startupTimeout.seconds))
-            c.start()
-            c
-          }
-        )(c => ZIO.attempt(c.stop()).orDie)
+                       ZIO.attempt {
+                         val c = PostgreSQLContainer(imgN)
+                         c.withUsername(config.username)
+                         c.withPassword(config.password)
+                         c.withDatabaseName(config.database)
+                         config.initScript.foreach(p => c.withInitScript(p.toString))
+                         c.withStartupAttempts(config.startupAttempts)
+                         c.withStartupTimeout(Duration.ofSeconds(config.startupTimeout))
+                         c.withReuse(true)
+                         c.waitingFor(Wait.forListeningPort().withStartupTimeout(config.startupTimeout.seconds))
+                         c.start()
+                         c
+                       }
+                     )(c => ZIO.attempt(c.stop()).orDie)
       yield container
 
   private def mkDataSource: ZLayer[PostgreSQLContainer[?], Throwable, HikariDataSource] =
     ZLayer.scoped:
-      for 
+      for
         container <- ZIO.service[PostgreSQLContainer[?]]
-        ds <- ZIO.acquireRelease(
-          ZIO.attempt {
-            val ds = new HikariDataSource()
-            // IMPORTANT: trust Testcontainers' URL (includes host + mapped port + params)
-            val url = {
-              val u = container.getJdbcUrl
-              if (u.contains("sslmode=")) u
-              else u + (if (u.contains("?")) "&" else "?") + "sslmode=disable"
-            }
-            ds.setJdbcUrl(url)
-            ds.setUsername(container.getUsername)
-            ds.setPassword(container.getPassword)
-            ds.setMaximumPoolSize(4)
-            ds.setMinimumIdle(1)
-            ds.setAutoCommit(true)
-            ds.setKeepaliveTime(30_000)     // keep connections warm on CI
-            ds.setIdleTimeout(120_000)
-            ds.setMaxLifetime(600_000)
-            ds.setValidationTimeout(5_000)
-            ds.setConnectionTimeout(10_000)
-            ds.setPoolName("pg-tests")
-            // optional, can help on noisy runners:
-            ds.setConnectionTestQuery("SELECT 1")
-            ds
-          }
-        )(ds => ZIO.attempt(ds.close()).orDie)
+        ds        <- ZIO.acquireRelease(
+                       ZIO.attempt {
+                         val ds  = new HikariDataSource()
+                         // IMPORTANT: trust Testcontainers' URL (includes host + mapped port + params)
+                         val url = {
+                           val u = container.getJdbcUrl
+                           if (u.contains("sslmode=")) u
+                           else u + (if (u.contains("?")) "&" else "?") + "sslmode=disable"
+                         }
+                         ds.setJdbcUrl(url)
+                         ds.setUsername(container.getUsername)
+                         ds.setPassword(container.getPassword)
+                         ds.setMaximumPoolSize(4)
+                         ds.setMinimumIdle(1)
+                         ds.setAutoCommit(true)
+                         ds.setKeepaliveTime(30_000) // keep connections warm on CI
+                         ds.setIdleTimeout(120_000)
+                         ds.setMaxLifetime(600_000)
+                         ds.setValidationTimeout(5_000)
+                         ds.setConnectionTimeout(10_000)
+                         ds.setPoolName("pg-tests")
+                         // optional, can help on noisy runners:
+                         ds.setConnectionTestQuery("SELECT 1")
+                         ds
+                       }
+                     )(ds => ZIO.attempt(ds.close()).orDie)
       yield ds
 
   val transactorLayer: ZLayer[DataSource, Nothing, TransactorZIO] =
-    TransactorZIO.layer  
-  
+    TransactorZIO.layer
+
   val layer: ZLayer[PgTestConfig, Throwable, TransactorZIO] =
     mkContainer >>> mkDataSource >>> transactorLayer
-

--- a/modules/s3/src/main/scala/graviton/s3/S3BlobStore.scala
+++ b/modules/s3/src/main/scala/graviton/s3/S3BlobStore.scala
@@ -8,17 +8,17 @@ import io.minio.{GetObjectArgs, PutObjectArgs, RemoveObjectArgs}
 import java.io.ByteArrayInputStream
 
 final class S3BlobStore(
-    client: MinioClient,
-    bucket: String,
-    val id: BlobStoreId
+  client: MinioClient,
+  bucket: String,
+  val id: BlobStoreId,
 ) extends BlobStore:
   private def keyPath(key: BlockKey): String = key.hash.hex
 
   def status: UIO[BlobStoreStatus] = ZIO.succeed(BlobStoreStatus.Operational)
 
   def read(
-      key: BlockKey,
-      range: Option[ByteRange] = None
+    key: BlockKey,
+    range: Option[ByteRange] = None,
   ): IO[Throwable, Option[Bytes]] =
     val builder = GetObjectArgs.builder.bucket(bucket).`object`(keyPath(key))
     range.foreach { case ByteRange(start, end) =>
@@ -26,27 +26,24 @@ final class S3BlobStore(
     }
     ZIO
       .attemptBlocking(client.getObject(builder.build()))
-      .map(is =>
-        Some(Bytes(ZStream.fromInputStream(is).mapError(e => e: Throwable)))
-      )
+      .map(is => Some(Bytes(ZStream.fromInputStream(is).mapError(e => e: Throwable))))
       .catchSome {
-        case e: io.minio.errors.ErrorResponseException
-            if e.errorResponse().code() == "NoSuchKey" =>
+        case e: io.minio.errors.ErrorResponseException if e.errorResponse().code() == "NoSuchKey" =>
           ZIO.succeed(None)
       }
 
   def write(key: BlockKey, data: Bytes): IO[Throwable, Unit] =
     for
       arr <- data.runCollect.map(_.toArray)
-      _ <- ZIO.attemptBlocking(
-        client.putObject(
-          PutObjectArgs.builder
-            .bucket(bucket)
-            .`object`(keyPath(key))
-            .stream(new ByteArrayInputStream(arr), arr.length, -1)
-            .build()
-        )
-      )
+      _   <- ZIO.attemptBlocking(
+               client.putObject(
+                 PutObjectArgs.builder
+                   .bucket(bucket)
+                   .`object`(keyPath(key))
+                   .stream(new ByteArrayInputStream(arr), arr.length, -1)
+                   .build()
+               )
+             )
     yield ()
 
   def delete(key: BlockKey): IO[Throwable, Boolean] =
@@ -59,9 +56,9 @@ final class S3BlobStore(
 
 object S3BlobStore:
   def layer(
-      client: MinioClient,
-      bucket: String,
-      id: String = "s3"
+    client: MinioClient,
+    bucket: String,
+    id: String = "s3",
   ): ZLayer[Any, Nothing, BlobStore] =
     ZLayer.succeed(
       new S3BlobStore(client, bucket, BlobStoreId(id)): BlobStore

--- a/modules/s3/src/test/scala/graviton/s3/S3BlobStoreSpec.scala
+++ b/modules/s3/src/test/scala/graviton/s3/S3BlobStoreSpec.scala
@@ -31,23 +31,23 @@ object S3BlobStoreSpec extends ZIOSpecDefault:
             .build()
           val bucket = "test"
           for
-            _ <- ZIO.attempt(
-              client.makeBucket(MakeBucketArgs.builder().bucket(bucket).build())
-            )
-            store = new S3BlobStore(client, bucket, BlobStoreId("test"))
-            data = Chunk.fromArray("hello".getBytes)
+            _         <- ZIO.attempt(
+                           client.makeBucket(MakeBucketArgs.builder().bucket(bucket).build())
+                         )
+            store      = new S3BlobStore(client, bucket, BlobStoreId("test"))
+            data       = Chunk.fromArray("hello".getBytes)
             hashBytes <- Hashing
-              .compute(Bytes(ZStream.fromChunk(data)), HashAlgorithm.SHA256)
-            digest = hashBytes.assume[MinLength[16] & MaxLength[64]]
-            hash = Hash(digest, HashAlgorithm.SHA256)
-            key = BlockKey(hash, data.length.assume[Positive])
-            _ <- store.write(key, Bytes(ZStream.fromChunk(data)))
-            outOpt <- store.read(key)
-            out <- outOpt match
-              case Some(bs) => bs.runCollect
-              case None     => ZIO.fail(new RuntimeException("missing data"))
-            deleted <- store.delete(key)
-            missing <- store.read(key)
+                           .compute(Bytes(ZStream.fromChunk(data)), HashAlgorithm.SHA256)
+            digest     = hashBytes.assume[MinLength[16] & MaxLength[64]]
+            hash       = Hash(digest, HashAlgorithm.SHA256)
+            key        = BlockKey(hash, data.length.assume[Positive])
+            _         <- store.write(key, Bytes(ZStream.fromChunk(data)))
+            outOpt    <- store.read(key)
+            out       <- outOpt match
+                           case Some(bs) => bs.runCollect
+                           case None     => ZIO.fail(new RuntimeException("missing data"))
+            deleted   <- store.delete(key)
+            missing   <- store.read(key)
           yield assertTrue(out == data, deleted, missing.isEmpty)
         }
       }


### PR DESCRIPTION
## Summary
- format Scala sources using `scalafmtAll`
- handle optional init script path when starting PostgreSQL Testcontainers to avoid resource errors

## Testing
- `./sbt scalafmtAll`


------
https://chatgpt.com/codex/tasks/task_b_68ba49f7d89c832e8fbdfc867200af0c