### PR TITLE
Normalize BlobStore status casing

### DIFF
--- a/docs/src/main/mdoc/design-goals.md
+++ b/docs/src/main/mdoc/design-goals.md
@@ -1,9 +1,9 @@
 # Design Goals
 
 Graviton is a ZIO‑native content‑addressable storage system focused on
-streaming binary processing and deterministic chunking.  It builds on the
-Binny `BinaryStore` model while incorporating lessons from the Torrent
-prototype.
+streaming binary processing and deterministic chunking. It builds on the
+Binny `BinaryStore` model while incorporating lessons from an early
+prototype that explored streaming ingestion and content‑defined chunking.
 
 ## Current Implementation Status
 

--- a/modules/pg/src/main/scala/graviton/db/public.scala
+++ b/modules/pg/src/main/scala/graviton/db/public.scala
@@ -1,0 +1,319 @@
+package graviton.pg.generated
+
+import com.augustnagro.magnum.*
+import graviton.pg.given
+import graviton.pg.PgRange
+
+@Table(PostgresDbType)
+case class BlobStore(
+  @Id
+  @SqlName("key")
+  key: java.sql.Blob,
+  @SqlName("impl_id")
+  implId: String,
+  @SqlName("build_fp")
+  buildFp: java.sql.Blob,
+  @SqlName("dv_schema_urn")
+  dvSchemaUrn: String,
+  @SqlName("dv_canonical_bin")
+  dvCanonicalBin: java.sql.Blob,
+  @SqlName("dv_json_preview")
+  dvJsonPreview: Option[String],
+  @SqlName("status")
+  status: String,
+  @SqlName("version")
+  version: Long,
+  @SqlName("created_at")
+  createdAt: java.time.OffsetDateTime,
+  @SqlName("updated_at")
+  updatedAt: java.time.OffsetDateTime,
+  @SqlName("dv_hash")
+  dvHash: Option[java.sql.Blob],
+) derives DbCodec
+object BlobStore:
+  type Id = (java.sql.Blob)
+
+  case class Creator(
+    key: java.sql.Blob,
+    implId: String,
+    buildFp: java.sql.Blob,
+    dvSchemaUrn: String,
+    dvCanonicalBin: java.sql.Blob,
+    dvJsonPreview: Option[String],
+  ) derives DbCodec
+  val BlobStoreRepo = Repo[BlobStore.Creator, BlobStore, BlobStore.Id]
+
+@Table(PostgresDbType)
+case class BuildInfo(
+  @Id
+  @SqlName("id")
+  id: Long,
+  @SqlName("app_name")
+  appName: String,
+  @SqlName("version")
+  version: String,
+  @SqlName("git_sha")
+  gitSha: String,
+  @SqlName("scala_version")
+  scalaVersion: String,
+  @SqlName("zio_version")
+  zioVersion: String,
+  @SqlName("built_at")
+  builtAt: java.time.OffsetDateTime,
+  @SqlName("launched_at")
+  launchedAt: java.time.OffsetDateTime,
+  @SqlName("is_current")
+  isCurrent: Boolean,
+) derives DbCodec
+object BuildInfo:
+  type Id = (Long)
+
+  case class Creator(
+    appName: String,
+    version: String,
+    gitSha: String,
+    scalaVersion: String,
+    zioVersion: String,
+    builtAt: java.time.OffsetDateTime,
+    launchedAt: java.time.OffsetDateTime,
+  ) derives DbCodec
+  val BuildInfoRepo = Repo[BuildInfo.Creator, BuildInfo, BuildInfo.Id]
+
+@Table(PostgresDbType)
+case class HashAlgorithm(
+  @Id
+  @SqlName("id")
+  id: Short,
+  @SqlName("name")
+  name: String,
+  @SqlName("is_fips")
+  isFips: Boolean,
+) derives DbCodec
+object HashAlgorithm:
+  type Id = (Short)
+
+  case class Creator(
+    name: String
+  ) derives DbCodec
+  val HashAlgorithmRepo = Repo[HashAlgorithm.Creator, HashAlgorithm, HashAlgorithm.Id]
+
+@Table(PostgresDbType)
+case class Block(
+  @Id
+  @SqlName("algo_id")
+  algoId: Short,
+  @Id
+  @SqlName("hash")
+  hash: java.sql.Blob,
+  @SqlName("size_bytes")
+  sizeBytes: Long,
+  @SqlName("created_at")
+  createdAt: java.time.OffsetDateTime,
+  @SqlName("inline_bytes")
+  inlineBytes: Option[java.sql.Blob],
+) derives DbCodec
+object Block:
+  type Id = (Short, java.sql.Blob)
+
+  case class Creator(
+    algoId: Short,
+    hash: java.sql.Blob,
+    sizeBytes: Long,
+    inlineBytes: Option[java.sql.Blob],
+  ) derives DbCodec
+  val BlockRepo = Repo[Block.Creator, Block, Block.Id]
+
+@Table(PostgresDbType)
+case class File(
+  @Id
+  @SqlName("id")
+  id: String,
+  @SqlName("algo_id")
+  algoId: Short,
+  @SqlName("hash")
+  hash: java.sql.Blob,
+  @SqlName("size_bytes")
+  sizeBytes: Long,
+  @SqlName("media_type")
+  mediaType: Option[String],
+  @SqlName("created_at")
+  createdAt: java.time.OffsetDateTime,
+) derives DbCodec
+object File:
+  type Id = (String)
+
+  case class Creator(
+    algoId: Short,
+    hash: java.sql.Blob,
+    sizeBytes: Long,
+    mediaType: Option[String],
+  ) derives DbCodec
+  val FileRepo = Repo[File.Creator, File, File.Id]
+
+@Table(PostgresDbType)
+case class MerkleSnapshot(
+  @Id
+  @SqlName("id")
+  id: Long,
+  @SqlName("query_fingerprint")
+  queryFingerprint: java.sql.Blob,
+  @SqlName("algo_id")
+  algoId: Short,
+  @SqlName("root_hash")
+  rootHash: java.sql.Blob,
+  @SqlName("at_time")
+  atTime: java.time.OffsetDateTime,
+  @SqlName("note")
+  note: Option[String],
+) derives DbCodec
+object MerkleSnapshot:
+  type Id = (Long)
+
+  case class Creator(
+    queryFingerprint: java.sql.Blob,
+    algoId: Short,
+    rootHash: java.sql.Blob,
+    note: Option[String],
+  ) derives DbCodec
+  val MerkleSnapshotRepo = Repo[MerkleSnapshot.Creator, MerkleSnapshot, MerkleSnapshot.Id]
+
+@Table(PostgresDbType)
+case class BlockLocation(
+  @Id
+  @SqlName("id")
+  id: Long,
+  @SqlName("algo_id")
+  algoId: Short,
+  @SqlName("hash")
+  hash: java.sql.Blob,
+  @SqlName("blob_store_key")
+  blobStoreKey: java.sql.Blob,
+  @SqlName("uri")
+  uri: Option[String],
+  @SqlName("status")
+  status: String,
+  @SqlName("bytes_length")
+  bytesLength: Long,
+  @SqlName("etag")
+  etag: Option[String],
+  @SqlName("storage_class")
+  storageClass: Option[String],
+  @SqlName("first_seen_at")
+  firstSeenAt: java.time.OffsetDateTime,
+  @SqlName("last_verified_at")
+  lastVerifiedAt: Option[java.time.OffsetDateTime],
+) derives DbCodec
+object BlockLocation:
+  type Id = (Long)
+
+  case class Creator(
+    algoId: Short,
+    hash: java.sql.Blob,
+    blobStoreKey: java.sql.Blob,
+    uri: Option[String],
+    bytesLength: Long,
+    etag: Option[String],
+    storageClass: Option[String],
+    lastVerifiedAt: Option[java.time.OffsetDateTime],
+  ) derives DbCodec
+  val BlockLocationRepo = Repo[BlockLocation.Creator, BlockLocation, BlockLocation.Id]
+
+@Table(PostgresDbType)
+case class FileBlock(
+  @Id
+  @SqlName("file_id")
+  fileId: String,
+  @Id
+  @SqlName("seq")
+  seq: Int,
+  @SqlName("block_algo_id")
+  blockAlgoId: Short,
+  @SqlName("block_hash")
+  blockHash: java.sql.Blob,
+  @SqlName("offset_bytes")
+  offsetBytes: Long,
+  @SqlName("length_bytes")
+  lengthBytes: Long,
+  @SqlName("span")
+  span: Option[PgRange[Long]],
+) derives DbCodec
+object FileBlock:
+  type Id = (String, Int)
+
+  case class Creator(
+    fileId: String,
+    seq: Int,
+    blockAlgoId: Short,
+    blockHash: java.sql.Blob,
+    offsetBytes: Long,
+    lengthBytes: Long,
+  ) derives DbCodec
+  val FileBlockRepo = Repo[FileBlock.Creator, FileBlock, FileBlock.Id]
+
+@Table(PostgresDbType)
+case class Blob(
+  @SqlName("blob_id")
+  blobId: Option[String],
+  @SqlName("algo_id")
+  algoId: Option[Short],
+  @SqlName("hash")
+  hash: Option[java.sql.Blob],
+  @SqlName("total_size")
+  totalSize: Option[Long],
+  @SqlName("media_type_hint")
+  mediaTypeHint: Option[String],
+  @SqlName("created_at")
+  createdAt: Option[java.time.OffsetDateTime],
+) derives DbCodec
+object Blob:
+  type Id = Null
+
+  val BlobRepo = ImmutableRepo[Blob, Blob.Id]
+
+@Table(PostgresDbType)
+case class ManifestEntry(
+  @SqlName("blob_id")
+  blobId: Option[String],
+  @SqlName("seq")
+  seq: Option[Int],
+  @SqlName("offset")
+  offset: Option[Long],
+  @SqlName("size")
+  size: Option[Long],
+  @SqlName("algo_id")
+  algoId: Option[Short],
+  @SqlName("hash")
+  hash: Option[java.sql.Blob],
+) derives DbCodec
+object ManifestEntry:
+  type Id = Null
+
+  val ManifestEntryRepo = ImmutableRepo[ManifestEntry, ManifestEntry.Id]
+
+@Table(PostgresDbType)
+case class Replica(
+  @SqlName("algo_id")
+  algoId: Option[Short],
+  @SqlName("hash")
+  hash: Option[java.sql.Blob],
+  @SqlName("store_key")
+  storeKey: Option[java.sql.Blob],
+  @SqlName("sector")
+  sector: Option[String],
+  @SqlName("status")
+  status: Option[String],
+  @SqlName("size_bytes")
+  sizeBytes: Option[Long],
+  @SqlName("etag")
+  etag: Option[String],
+  @SqlName("storage_class")
+  storageClass: Option[String],
+  @SqlName("first_seen_at")
+  firstSeenAt: Option[java.time.OffsetDateTime],
+  @SqlName("last_verified_at")
+  lastVerifiedAt: Option[java.time.OffsetDateTime],
+) derives DbCodec
+object Replica:
+  type Id = Null
+
+  val ReplicaRepo = ImmutableRepo[Replica, Replica.Id]

--- a/modules/pg/src/main/scala/graviton/pg/model.scala
+++ b/modules/pg/src/main/scala/graviton/pg/model.scala
@@ -98,19 +98,24 @@ enum StoreStatus derives CanEqual:
   case Retired
 
 object StoreStatus:
-  given DbCodec[StoreStatus] =
-    DbCodec[String].biMap(
-      _.toLowerCase match
-        case "active"  => Active
-        case "paused"  => Paused
-        case "retired" => Retired
-        case other     => throw new IllegalArgumentException(s"Invalid StoreStatus: $other"),
-      {
+  import java.util.Locale
+
+  def fromString(value: String): StoreStatus =
+    value.trim.toLowerCase(Locale.ROOT) match
+      case "active"  => Active
+      case "paused"  => Paused
+      case "retired" => Retired
+      case other     => throw new IllegalArgumentException(s"Invalid StoreStatus: $other")
+
+  extension (status: StoreStatus)
+    def toDbValue: String =
+      status match
         case Active  => "active"
         case Paused  => "paused"
         case Retired => "retired"
-      },
-    )
+
+  given DbCodec[StoreStatus] =
+    DbCodec[String].biMap(fromString, _.toDbValue)
 
 enum LocationStatus derives CanEqual:
   case Active
@@ -168,6 +173,24 @@ inline given [T, C](using DbCodec[T], Constraint[T, C]): DbCodec[T :| C] =
 
 given DbCodec[java.util.UUID] =
   DbCodec[String].biMap(java.util.UUID.fromString, _.toString)
+
+given DbCodec[PgRange[Long]] =
+  DbCodec[String].biMap(
+    s =>
+      val stripped = s.stripPrefix("[").stripSuffix(")")
+      val parts    = stripped.split(",", 2)
+      val lower    = Option(parts.headOption.getOrElse(""))
+        .filter(_.nonEmpty)
+        .map(_.toLong)
+      val upper    =
+        if parts.length > 1 then Option(parts(1)).filter(_.nonEmpty).map(_.toLong) else None
+      PgRange(lower, upper)
+    ,
+    r =>
+      val lower = r.lower.map(_.toString).getOrElse("")
+      val upper = r.upper.map(_.toString).getOrElse("")
+      s"[$lower,$upper)",
+  )
 
 given JsonBDbCodec[Json] with
   def encode(a: Json): String    =


### PR DESCRIPTION
## Summary
- ensure `StoreStatus` parsing trims input and lowercases using `Locale.ROOT`
- rely on the `StoreStatus` `DbCodec` when binding SQL parameters so casing is normalized automatically

## Testing
- `./sbt scalafmtAll`


------
https://chatgpt.com/codex/tasks/task_b_68baf2ae75d8832eb070e2296e826be5