### PR TITLE
Add refined schema support for iron types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,3 @@ This file captures future work items discussed with the AI.
 
 ### Additional enhancements
 - Document CLI/HTTP usage, configuration examples for filesystem and S3 backends, richer metrics/logging snippets, broader test coverage (including TestContainers), and CI workflows for publishing to Maven Central.
-
-## Workflow Requirements
-
-- Always run `./sbt scalafmtAll && ./sbt test` before committing or opening a pull request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,7 @@ This file captures future work items discussed with the AI.
 
 ### Additional enhancements
 - Document CLI/HTTP usage, configuration examples for filesystem and S3 backends, richer metrics/logging snippets, broader test coverage (including TestContainers), and CI workflows for publishing to Maven Central.
+
+## Workflow Requirements
+
+- Always run `./sbt scalafmtAll && ./sbt test` before committing or opening a pull request.

--- a/docs/src/main/mdoc/getting-started/quick-start.md
+++ b/docs/src/main/mdoc/getting-started/quick-start.md
@@ -7,12 +7,11 @@ import zio.*
 import zio.stream.*
 import graviton.*
 import graviton.impl.InMemoryBinaryStore
-import graviton.core.BinaryAttributes
 
 def storeAndFetch(store: BinaryStore): ZIO[Any, Throwable, Option[Bytes]] =
   for
     id <- ZStream.fromIterable("Hello, Graviton!".getBytes)
-            .run(store.put(BinaryAttributes.empty, chunkSize = 1024 * 1024))
+            .run(store.put)
     data <- store.get(id)
   yield data
 ```

--- a/modules/core/src/main/scala/graviton/BinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/BinaryStore.scala
@@ -1,14 +1,10 @@
 package graviton
 
-import graviton.core.BinaryAttributes
 import zio.*
 import zio.stream.*
 
 trait BinaryStore:
-  def put(
-    attrs: BinaryAttributes,
-    chunkSize: Int,
-  ): ZSink[Any, Throwable, Byte, Nothing, BinaryId]
+  def put: ZSink[Any, Throwable, Byte, Nothing, BinaryId]
   def get(
     id: BinaryId,
     range: Option[ByteRange] = None,

--- a/modules/core/src/main/scala/graviton/BlockKey.scala
+++ b/modules/core/src/main/scala/graviton/BlockKey.scala
@@ -1,8 +1,9 @@
 package graviton
 
+import graviton.core.model.Size
 import zio.schema.{DeriveSchema, Schema}
 
-final case class BlockKey(hash: Hash, size: Int)
+final case class BlockKey(hash: Hash, size: Size)
 
 final case class BlockKeySelector(prefix: Option[Array[Byte]] = None)
 

--- a/modules/core/src/main/scala/graviton/Scan.scala
+++ b/modules/core/src/main/scala/graviton/Scan.scala
@@ -6,7 +6,7 @@ import zio.ChunkBuilder
 import zio.stream.Take
 import zio.prelude.fx.ZPure
 // import scala.compiletime.{erasedValue, summonFrom}
-import io.github.iltotore.iron.*
+import io.github.iltotore.iron.{zio => _, *}
 import io.github.iltotore.iron.constraint.all.*
 
 /**

--- a/modules/core/src/main/scala/graviton/chunking/Chunker.scala
+++ b/modules/core/src/main/scala/graviton/chunking/Chunker.scala
@@ -1,12 +1,12 @@
 package graviton.chunking
 
-import zio.*
+import graviton.core.model.Block
 import zio.stream.*
 
 /** Splits a byte stream into logical chunks. */
 trait Chunker:
   def name: String
-  def pipeline: ZPipeline[Any, Throwable, Byte, Chunk[Byte]]
+  def pipeline: ZPipeline[Any, Throwable, Byte, Block]
 
 object Chunker:
 

--- a/modules/core/src/main/scala/graviton/chunking/FixedChunker.scala
+++ b/modules/core/src/main/scala/graviton/chunking/FixedChunker.scala
@@ -1,5 +1,6 @@
 package graviton.chunking
 
+import graviton.core.model.Block
 import zio.*
 import zio.stream.*
 
@@ -7,29 +8,34 @@ import zio.stream.*
 object FixedChunker:
   def apply(size: Int): Chunker =
     new Chunker:
-      val name                                                   = s"fixed($size)"
-      val pipeline: ZPipeline[Any, Throwable, Byte, Chunk[Byte]] =
-        ZPipeline.fromChannel:
-          def splitAll(acc: Chunk[Byte]): (Chunk[Chunk[Byte]], Chunk[Byte]) =
-            var rest = acc
-            val outs = scala.collection.mutable.ListBuffer.empty[Chunk[Byte]]
-            while rest.length >= size do
-              val (full, r) = rest.splitAt(size)
-              outs += full
-              rest = r
-            (Chunk.fromIterable(outs.toList), rest)
+      val name                                             = s"fixed($size)"
+      val pipeline: ZPipeline[Any, Throwable, Byte, Block] =
+        ZPipeline
+          .fromChannel {
+            def splitAll(acc: Chunk[Byte]): (Chunk[Chunk[Byte]], Chunk[Byte]) =
+              var rest = acc
+              val outs = scala.collection.mutable.ListBuffer.empty[Chunk[Byte]]
+              while rest.length >= size do
+                val (full, r) = rest.splitAt(size)
+                outs += full
+                rest = r
+              (Chunk.fromIterable(outs.toList), rest)
 
-          def loop(buf: Chunk[Byte]): ZChannel[Any, Throwable, Chunk[
-            Byte
-          ], Any, Throwable, Chunk[Chunk[Byte]], Any] =
-            ZChannel.readWith(
-              (in: Chunk[Byte]) =>
-                val (emitted, leftover) = splitAll(buf ++ in)
-                ZChannel.write(emitted) *> loop(leftover)
-              ,
-              (err: Throwable) => ZChannel.fail(err),
-              (_: Any) =>
-                if buf.isEmpty then ZChannel.unit
-                else ZChannel.write(Chunk(buf)),
-            )
-          loop(Chunk.empty)
+            def loop(buf: Chunk[Byte]): ZChannel[Any, Throwable, Chunk[
+              Byte
+            ], Any, Throwable, Chunk[Chunk[Byte]], Any] =
+              ZChannel.readWith(
+                (in: Chunk[Byte]) =>
+                  val (emitted, leftover) = splitAll(buf ++ in)
+                  ZChannel.write(emitted) *> loop(leftover)
+                ,
+                (err: Throwable) => ZChannel.fail(err),
+                (_: Any) =>
+                  if buf.isEmpty then ZChannel.unit
+                  else ZChannel.write(Chunk(buf)),
+              )
+            loop(Chunk.empty)
+          }
+          .mapChunksZIO { chunked =>
+            ZIO.foreach(chunked)(bytes => ZIO.fromEither(Block.fromChunk(bytes)).mapError(err => new IllegalArgumentException(err)))
+          }

--- a/modules/core/src/main/scala/graviton/chunking/PdfChunker.scala
+++ b/modules/core/src/main/scala/graviton/chunking/PdfChunker.scala
@@ -1,5 +1,6 @@
 package graviton.chunking
 
+import graviton.core.model.Block
 import zio.*
 import zio.stream.*
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
@@ -10,18 +11,23 @@ import java.util.zip.InflaterInputStream
  * stream data.
  */
 object PdfChunker extends Chunker:
-  val name                                                   = "pdf"
-  val pipeline: ZPipeline[Any, Throwable, Byte, Chunk[Byte]] =
-    ZPipeline.fromChannel:
-      def loop(buf: Chunk[Byte]): ZChannel[Any, Throwable, Chunk[
-        Byte
-      ], Any, Throwable, Chunk[Chunk[Byte]], Any] =
-        ZChannel.readWith(
-          (in: Chunk[Byte]) => loop(buf ++ in),
-          (err: Throwable) => ZChannel.fail(err),
-          (_: Any) => ZChannel.write(split(buf)),
-        )
-      loop(Chunk.empty)
+  val name                                             = "pdf"
+  val pipeline: ZPipeline[Any, Throwable, Byte, Block] =
+    ZPipeline
+      .fromChannel {
+        def loop(buf: Chunk[Byte]): ZChannel[Any, Throwable, Chunk[
+          Byte
+        ], Any, Throwable, Chunk[Chunk[Byte]], Any] =
+          ZChannel.readWith(
+            (in: Chunk[Byte]) => loop(buf ++ in),
+            (err: Throwable) => ZChannel.fail(err),
+            (_: Any) => ZChannel.write(split(buf)),
+          )
+        loop(Chunk.empty)
+      }
+      .mapChunksZIO { chunked =>
+        ZIO.foreach(chunked)(bytes => ZIO.fromEither(Block.fromChunk(bytes)).mapError(err => new IllegalArgumentException(err)))
+      }
 
   private val streamToken    = "stream".getBytes("ISO-8859-1")
   private val endStreamToken = "endstream".getBytes("ISO-8859-1")

--- a/modules/core/src/main/scala/graviton/chunking/RollingHashChunker.scala
+++ b/modules/core/src/main/scala/graviton/chunking/RollingHashChunker.scala
@@ -1,5 +1,6 @@
 package graviton.chunking
 
+import graviton.core.model.Block
 import zio.*
 import zio.stream.*
 
@@ -14,24 +15,29 @@ object RollingHashChunker:
 
   def apply(cfg: Config): Chunker =
     new Chunker:
-      val name                                                   =
+      val name                                             =
         s"rolling(min=${cfg.bounds.min},avg=${cfg.bounds.avg},max=${cfg.bounds.max})"
-      val pipeline: ZPipeline[Any, Throwable, Byte, Chunk[Byte]] =
-        ZPipeline.fromChannel:
-          def loop(state: State): ZChannel[Any, Throwable, Chunk[
-            Byte
-          ], Any, Throwable, Chunk[Chunk[Byte]], Any] =
-            ZChannel.readWith(
-              (in: Chunk[Byte]) =>
-                val (next, out) = process(state, in, cfg)
-                ZChannel.write(out) *> loop(next)
-              ,
-              (err: Throwable) => ZChannel.fail(err),
-              (_: Any) =>
-                if state.buffer.isEmpty then ZChannel.unit
-                else ZChannel.write(Chunk.single(state.buffer)),
-            )
-          loop(State.empty(cfg))
+      val pipeline: ZPipeline[Any, Throwable, Byte, Block] =
+        ZPipeline
+          .fromChannel {
+            def loop(state: State): ZChannel[Any, Throwable, Chunk[
+              Byte
+            ], Any, Throwable, Chunk[Chunk[Byte]], Any] =
+              ZChannel.readWith(
+                (in: Chunk[Byte]) =>
+                  val (next, out) = process(state, in, cfg)
+                  ZChannel.write(out) *> loop(next)
+                ,
+                (err: Throwable) => ZChannel.fail(err),
+                (_: Any) =>
+                  if state.buffer.isEmpty then ZChannel.unit
+                  else ZChannel.write(Chunk.single(state.buffer)),
+              )
+            loop(State.empty(cfg))
+          }
+          .mapChunksZIO { chunked =>
+            ZIO.foreach(chunked)(bytes => ZIO.fromEither(Block.fromChunk(bytes)).mapError(err => new IllegalArgumentException(err)))
+          }
 
   private final case class State(
     cfg: Config,

--- a/modules/core/src/main/scala/graviton/chunking/TokenAwareChunker.scala
+++ b/modules/core/src/main/scala/graviton/chunking/TokenAwareChunker.scala
@@ -1,24 +1,30 @@
 package graviton.chunking
 
+import graviton.core.model.Block
 import zio.*
 import zio.stream.*
 
 object TokenAwareChunker:
 
-  def pipeline(tokens: Set[String], maxChunkSize: Int): ZPipeline[Any, Throwable, Byte, Chunk[Byte]] =
-    ZPipeline.fromChannel:
-      def loop(state: State): ZChannel[Any, Throwable, Chunk[
-        Byte
-      ], Any, Throwable, Chunk[Chunk[Byte]], Any] =
-        ZChannel.readWith(
-          (in: Chunk[Byte]) =>
-            val (next, out) = process(state, in, tokens, maxChunkSize)
-            ZChannel.write(out) *> loop(next)
-          ,
-          (err: Throwable) => ZChannel.fail(err),
-          (_: Any) => if state.buffer.isEmpty then ZChannel.unit else ZChannel.write(Chunk.single(state.buffer)),
-        )
-      loop(State.empty)
+  def pipeline(tokens: Set[String], maxChunkSize: Int): ZPipeline[Any, Throwable, Byte, Block] =
+    ZPipeline
+      .fromChannel {
+        def loop(state: State): ZChannel[Any, Throwable, Chunk[
+          Byte
+        ], Any, Throwable, Chunk[Chunk[Byte]], Any] =
+          ZChannel.readWith(
+            (in: Chunk[Byte]) =>
+              val (next, out) = process(state, in, tokens, maxChunkSize)
+              ZChannel.write(out) *> loop(next)
+            ,
+            (err: Throwable) => ZChannel.fail(err),
+            (_: Any) => if state.buffer.isEmpty then ZChannel.unit else ZChannel.write(Chunk.single(state.buffer)),
+          )
+        loop(State.empty)
+      }
+      .mapChunksZIO { chunked =>
+        ZIO.foreach(chunked)(bytes => ZIO.fromEither(Block.fromChunk(bytes)).mapError(err => new IllegalArgumentException(err)))
+      }
 
   private final case class State(buffer: Chunk[Byte], recent: String)
   private object State:

--- a/modules/core/src/main/scala/graviton/core/RefinedSchemas.scala
+++ b/modules/core/src/main/scala/graviton/core/RefinedSchemas.scala
@@ -1,0 +1,19 @@
+package graviton.core
+
+import io.github.iltotore.iron.{zio => _, *}
+import io.github.iltotore.iron.RuntimeConstraint
+import zio.schema.*
+import zio.schema.annotation.description
+
+object refined:
+  given [A, C](using schema: Schema[A], constraint: RuntimeConstraint[A, C]): Schema[A :| C] =
+    schema
+      .annotate(description(constraint.message))
+      .transformOrFail(
+        a =>
+          a
+            .refineEither[C]
+            .left
+            .map(err => s"${constraint.message}: $err"),
+        refined => Right(refined.asInstanceOf[A]),
+      )

--- a/modules/core/src/main/scala/graviton/core/model/Block.scala
+++ b/modules/core/src/main/scala/graviton/core/model/Block.scala
@@ -1,0 +1,101 @@
+package graviton.core.model
+
+import graviton.GravitonError
+import io.github.iltotore.iron.{zio => _, *}
+import io.github.iltotore.iron.constraint.numeric.*
+import zio.*
+import zio.stream.*
+
+/** Project-wide constant limits. */
+object Limits:
+  inline val MAX_BLOCK_SIZE_IN_BYTES = 1048576
+
+/** Size measured in bytes. Always strictly positive. */
+type Size = Int :| Positive
+
+object Size:
+  def apply(n: Int): Either[String, Size] = n.refineEither[Positive]
+
+  def fromZIO(n: Int): IO[GravitonError, Size] =
+    ZIO.fromEither(apply(n)).mapError(msg => GravitonError.PolicyViolation(msg))
+
+object IndexConstraint:
+  object NonNegative:
+    given RuntimeConstraint[Long, NonNegative.type] =
+      RuntimeConstraint[Long, NonNegative.type]((value: Long) => value >= 0L, "index must be >= 0")
+
+/** Zero-based indices. */
+type Index = Long :| IndexConstraint.NonNegative.type
+
+object Index:
+  def apply(n: Long): Either[String, Index] = n.refineEither[IndexConstraint.NonNegative.type]
+
+/** Immutable block of bytes constrained to 1..=MAX_BLOCK_SIZE_IN_BYTES. */
+final case class Block private (bytes: Chunk[Byte], size: Size):
+  def toChunk: Chunk[Byte] = bytes
+  def toArray: Array[Byte] = bytes.toArray
+
+object Block:
+  import Limits.MAX_BLOCK_SIZE_IN_BYTES
+
+  def fromChunk(bytes: Chunk[Byte]): Either[String, Block] =
+    val length = bytes.length
+    if length <= 0 then Left("chunk length must be > 0")
+    else if length > MAX_BLOCK_SIZE_IN_BYTES then Left(s"chunk length exceeds $MAX_BLOCK_SIZE_IN_BYTES")
+    else Size(length).map(size => Block(bytes, size))
+
+  def fromChunkZIO(bytes: Chunk[Byte]): IO[GravitonError, Block] =
+    ZIO.fromEither(fromChunk(bytes)).mapError(GravitonError.PolicyViolation.apply)
+
+  def unsafeFromChunk(bytes: Chunk[Byte]): Block =
+    fromChunk(bytes).fold(err => throw new IllegalArgumentException(err), identity)
+
+object BlockBuilder:
+  import Limits.MAX_BLOCK_SIZE_IN_BYTES
+
+  def chunkify(bytes: Chunk[Byte]): Chunk[Block] =
+    if bytes.isEmpty then Chunk.empty
+    else
+      val grouped = bytes.grouped(MAX_BLOCK_SIZE_IN_BYTES)
+      Chunk.fromIterator(
+        grouped.flatMap { group =>
+          val chunk = Chunk.fromIterable(group)
+          Block.fromChunk(chunk).toOption.iterator
+        }
+      )
+
+  def rechunk(max: Int = MAX_BLOCK_SIZE_IN_BYTES): ZPipeline[Any, GravitonError, Byte, Block] =
+    ZPipeline.fromChannel {
+      def emitFull(bytes: Chunk[Byte]): IO[GravitonError, (Chunk[Block], Chunk[Byte])] =
+        var rest = bytes
+        val out  = ChunkBuilder.make[Block]()
+        while rest.length >= max do
+          val (full, leftover) = rest.splitAt(max)
+          Block.fromChunk(full) match
+            case Left(err)  => return ZIO.fail(GravitonError.PolicyViolation(err))
+            case Right(blo) =>
+              out += blo
+              rest = leftover
+        ZIO.succeed(out.result() -> rest)
+
+      def loop(buffer: Chunk[Byte]): ZChannel[Any, GravitonError, Chunk[Byte], Any, GravitonError, Chunk[Block], Any] =
+        ZChannel.readWith(
+          (incoming: Chunk[Byte]) =>
+            ZChannel.fromZIO(emitFull(buffer ++ incoming)).flatMap { case (emitted, rest) =>
+              if emitted.isEmpty then loop(rest)
+              else ZChannel.write(emitted) *> loop(rest)
+            },
+          (err: GravitonError) => ZChannel.fail(err),
+          (_: Any) =>
+            if buffer.isEmpty then ZChannel.unit
+            else
+              ZChannel
+                .fromZIO(
+                  ZIO.fromEither(Block.fromChunk(buffer)).mapError(GravitonError.PolicyViolation.apply)
+                )
+                .flatMap { block =>
+                  ZChannel.write(Chunk.single(block))
+                },
+        )
+      loop(Chunk.empty)
+    }

--- a/modules/core/src/main/scala/graviton/core/package.scala
+++ b/modules/core/src/main/scala/graviton/core/package.scala
@@ -8,6 +8,8 @@ package object core:
   type Bytes        = ZStream[Any, Throwable, Byte]
   type StorageError = GravitonError
 
+  export refined.given
+
   given [K: Schema, V: Schema] => Schema[ListMap[K, V]] =
     Schema.list[((K, V))].transform(ListMap.from, _.toList)
 

--- a/modules/core/src/main/scala/graviton/hashing.scala
+++ b/modules/core/src/main/scala/graviton/hashing.scala
@@ -4,7 +4,7 @@ import zio.*
 import zio.stream.*
 import java.security.MessageDigest
 import io.github.rctcwyvrn.blake3.Blake3
-import io.github.iltotore.iron.*
+import io.github.iltotore.iron.{zio => _, *}
 import io.github.iltotore.iron.constraint.all.*
 
 /**

--- a/modules/core/src/main/scala/graviton/impl/DefaultCopyTool.scala
+++ b/modules/core/src/main/scala/graviton/impl/DefaultCopyTool.scala
@@ -1,7 +1,6 @@
 package graviton.impl
 
 import graviton.*
-import graviton.core.BinaryAttributes
 import zio.*
 
 /**
@@ -12,8 +11,6 @@ import zio.*
  * provided [[Hint]].
  */
 final class DefaultCopyTool extends CopyTool:
-  private val DefaultChunkSize: Int = 64 * 1024
-
   def copy(
     src: BinaryStore,
     dest: BinaryStore,
@@ -24,8 +21,7 @@ final class DefaultCopyTool extends CopyTool:
       bytes <- src
                  .get(id)
                  .someOrFail(GravitonError.NotFound(s"binary $id not found"))
-      _     <-
-        bytes.run(dest.put(BinaryAttributes.empty, DefaultChunkSize)).unit
+      _     <- bytes.run(dest.put).unit
     yield ()
 
     for

--- a/modules/core/src/main/scala/graviton/impl/InMemoryBinaryStore.scala
+++ b/modules/core/src/main/scala/graviton/impl/InMemoryBinaryStore.scala
@@ -1,16 +1,12 @@
 package graviton.impl
 
 import graviton.*
-import graviton.core.BinaryAttributes
 import zio.*
 import zio.stream.*
 
 final class InMemoryBinaryStore private (ref: Ref[Map[BinaryId, Chunk[Byte]]]) extends BinaryStore:
 
-  def put(
-    attrs: BinaryAttributes,
-    chunkSize: Int,
-  ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
+  def put: ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
     ZSink.collectAll[Byte].mapZIO { data =>
       val id = BinaryId(java.util.UUID.randomUUID().toString)
       ref.update(_ + (id -> data)).as(id)

--- a/modules/core/src/main/scala/graviton/refined.scala
+++ b/modules/core/src/main/scala/graviton/refined.scala
@@ -1,0 +1,3 @@
+package graviton
+
+export graviton.core.refined.given

--- a/modules/core/src/test/scala/graviton/BinaryStoreSpec.scala
+++ b/modules/core/src/test/scala/graviton/BinaryStoreSpec.scala
@@ -1,10 +1,9 @@
 package graviton
 
+import graviton.impl.*
 import zio.*
 import zio.stream.*
 import zio.test.*
-import graviton.impl.*
-import graviton.core.BinaryAttributes
 
 object BinaryStoreSpec extends ZIOSpecDefault:
 
@@ -12,14 +11,14 @@ object BinaryStoreSpec extends ZIOSpecDefault:
     test("store and retrieve data") {
       for
         store <- InMemoryBinaryStore.make()
-        id    <- ZStream.fromIterable("hello".getBytes).run(store.put(BinaryAttributes.empty, 1024))
+        id    <- ZStream.fromIterable("hello".getBytes).run(store.put)
         out   <- store.get(id).someOrFailException.flatMap(_.runCollect)
       yield assertTrue(new String(out.toArray) == "hello")
     },
     test("delete removes data") {
       for
         store  <- InMemoryBinaryStore.make()
-        id     <- ZStream.fromIterable("data".getBytes).run(store.put(BinaryAttributes.empty, 1024))
+        id     <- ZStream.fromIterable("data".getBytes).run(store.put)
         _      <- store.delete(id)
         exists <- store.exists(id)
       yield assertTrue(!exists)

--- a/modules/core/src/test/scala/graviton/ChunkerSpec.scala
+++ b/modules/core/src/test/scala/graviton/ChunkerSpec.scala
@@ -1,9 +1,10 @@
 package graviton
 
+import graviton.chunking.*
+import graviton.core.model.Block
 import zio.*
 import zio.stream.*
 import zio.test.*
-import graviton.chunking.*
 import java.util.zip.{Deflater, DeflaterOutputStream}
 import java.io.ByteArrayOutputStream
 
@@ -31,13 +32,12 @@ object ChunkerSpec extends ZIOSpecDefault:
     test("fixed chunker splits by size") {
       val data = Chunk.fromArray("abcdef".getBytes("UTF-8"))
       ZStream.fromChunk(data).via(FixedChunker(2).pipeline).runCollect.map { out =>
-        assertTrue(
-          out == Chunk(
-            Chunk.fromArray("ab".getBytes),
-            Chunk.fromArray("cd".getBytes),
-            Chunk.fromArray("ef".getBytes),
-          )
+        val expected = Chunk(
+          Block.unsafeFromChunk(Chunk.fromArray("ab".getBytes)),
+          Block.unsafeFromChunk(Chunk.fromArray("cd".getBytes)),
+          Block.unsafeFromChunk(Chunk.fromArray("ef".getBytes)),
         )
+        assertTrue(out.map(_.toChunk) == expected.map(_.toChunk))
       }
     },
     test("pdf chunker normalizes compressed streams") {
@@ -48,7 +48,7 @@ object ChunkerSpec extends ZIOSpecDefault:
         c1 <- ZStream.fromChunk(pdf1).via(PdfChunker.pipeline).runCollect
         c2 <- ZStream.fromChunk(pdf2).via(PdfChunker.pipeline).runCollect
       yield assertTrue(
-        c1 == c2 && c1.exists(_ == Chunk.fromArray(content))
+        c1.map(_.toChunk) == c2.map(_.toChunk) && c1.exists(_.toChunk == Chunk.fromArray(content))
       )
     },
   )

--- a/modules/core/src/test/scala/graviton/EncryptionSpec.scala
+++ b/modules/core/src/test/scala/graviton/EncryptionSpec.scala
@@ -1,11 +1,10 @@
 package graviton
 
+import graviton.core.model.Size
+import graviton.impl.*
 import zio.*
 import zio.stream.*
 import zio.test.*
-import graviton.impl.*
-import io.github.iltotore.iron.*
-import io.github.iltotore.iron.constraint.all.*
 
 object EncryptionSpec extends ZIOSpecDefault:
 
@@ -20,9 +19,8 @@ object EncryptionSpec extends ZIOSpecDefault:
                      Bytes(ZStream.fromIterable(data.toIndexedSeq)),
                      HashAlgorithm.SHA256,
                    )
-      digest     = hashBytes.assume[MinLength[16] & MaxLength[64]]
-      size       = data.length.assume[Positive]
-    yield BlockKey(Hash(digest, HashAlgorithm.SHA256), size)
+      size      <- Size.fromZIO(data.length).orDie
+    yield BlockKey(Hash(hashBytes, HashAlgorithm.SHA256), size)
 
   def spec =
     suite("EncryptionSpec")(

--- a/modules/core/src/test/scala/graviton/ScanSpec.scala
+++ b/modules/core/src/test/scala/graviton/ScanSpec.scala
@@ -3,7 +3,7 @@ package graviton
 import zio.*
 import zio.stream.*
 import zio.test.*
-import io.github.iltotore.iron.*
+import io.github.iltotore.iron.{zio => _, *}
 import io.github.iltotore.iron.constraint.all.*
 
 object ScanSpec extends ZIOSpecDefault:

--- a/modules/core/src/test/scala/graviton/logging/LoggingBinaryStoreSpec.scala
+++ b/modules/core/src/test/scala/graviton/logging/LoggingBinaryStoreSpec.scala
@@ -1,7 +1,6 @@
 package graviton.logging
 
 import graviton.{BinaryId, BinaryStore, ByteRange}
-import graviton.core.BinaryAttributes
 import zio.*
 import zio.stream.*
 import zio.test.*
@@ -10,18 +9,15 @@ import zio.test.ZTestLogger
 
 object LoggingBinaryStoreSpec extends ZIOSpecDefault:
   private val dummyStore = new BinaryStore:
-    def put(
-      attrs: BinaryAttributes,
-      chunkSize: Int,
-    ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
+    def put: ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
       ZSink.fail(new NotImplementedError("unused"))
     def get(
       id: BinaryId,
       range: Option[ByteRange],
     ): IO[Throwable, Option[graviton.Bytes]] =
       ZIO.succeed(None)
-    def delete(id: BinaryId): IO[Throwable, Boolean] = ZIO.succeed(true)
-    def exists(id: BinaryId): IO[Throwable, Boolean] = ZIO.succeed(true)
+    def delete(id: BinaryId): IO[Throwable, Boolean]        = ZIO.succeed(true)
+    def exists(id: BinaryId): IO[Throwable, Boolean]        = ZIO.succeed(true)
 
   def spec =
     suite("LoggingBinaryStore")(

--- a/modules/fs/src/test/scala/graviton/fs/DiskCacheStoreSpec.scala
+++ b/modules/fs/src/test/scala/graviton/fs/DiskCacheStoreSpec.scala
@@ -4,7 +4,7 @@ import graviton.*
 import zio.*
 import zio.stream.*
 import zio.test.*
-import io.github.iltotore.iron.*
+import io.github.iltotore.iron.{zio => _, *}
 import io.github.iltotore.iron.constraint.all.*
 import java.nio.file.Files
 

--- a/modules/fs/src/test/scala/graviton/fs/FileSystemBlobStoreSpec.scala
+++ b/modules/fs/src/test/scala/graviton/fs/FileSystemBlobStoreSpec.scala
@@ -4,7 +4,7 @@ import zio.*
 import zio.stream.*
 import zio.test.*
 import graviton.*
-import io.github.iltotore.iron.*
+import io.github.iltotore.iron.{zio => _, *}
 import io.github.iltotore.iron.constraint.all.*
 import java.nio.file.Files
 

--- a/modules/metrics/src/main/scala/graviton/metrics/MetricsBinaryStore.scala
+++ b/modules/metrics/src/main/scala/graviton/metrics/MetricsBinaryStore.scala
@@ -1,19 +1,15 @@
 package graviton.metrics
 
 import graviton.{BinaryId, BinaryStore, ByteRange}
-import graviton.core.BinaryAttributes
 import zio.*
 import zio.stream.*
 import Metrics.*
 
 final case class MetricsBinaryStore(underlying: BinaryStore) extends BinaryStore:
-  override def put(
-    attrs: BinaryAttributes,
-    chunkSize: Int,
-  ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
+  override def put: ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
     ZSink.unwrapScoped {
       Clock.nanoTime.map { start =>
-        underlying.put(attrs, chunkSize).mapZIO { id =>
+        underlying.put.mapZIO { id =>
           for
             end <- Clock.nanoTime
             _   <- putCount.increment

--- a/modules/metrics/src/test/scala/graviton/metrics/MetricsBinaryStoreSpec.scala
+++ b/modules/metrics/src/test/scala/graviton/metrics/MetricsBinaryStoreSpec.scala
@@ -1,26 +1,22 @@
 package graviton.metrics
 
 import graviton.{BinaryId, BinaryStore, ByteRange}
-import graviton.core.BinaryAttributes
 import zio.*
 import zio.stream.*
 import zio.test.*
 
 object MetricsBinaryStoreSpec extends ZIOSpecDefault:
   private val stub = new BinaryStore:
-    def put(
-      attrs: BinaryAttributes,
-      chunkSize: Int,
-    ): ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
+    def put: ZSink[Any, Throwable, Byte, Nothing, BinaryId] =
       ZSink.succeed(BinaryId("id"))
     def get(
       id: BinaryId,
       range: Option[ByteRange],
     ): IO[Throwable, Option[graviton.Bytes]] =
       ZIO.succeed(None)
-    def delete(id: BinaryId): IO[Throwable, Boolean] =
+    def delete(id: BinaryId): IO[Throwable, Boolean]        =
       ZIO.succeed(true)
-    def exists(id: BinaryId): IO[Throwable, Boolean] =
+    def exists(id: BinaryId): IO[Throwable, Boolean]        =
       ZIO.succeed(true)
 
   def spec = suite("MetricsBinaryStore")(

--- a/modules/pg/src/main/resources/generated/public.scala
+++ b/modules/pg/src/main/resources/generated/public.scala
@@ -4,7 +4,7 @@ import com.augustnagro.magnum.*
 import com.augustnagro.magnum.pg.enums.*
 import graviton.pg.given
 import graviton.pg.PgRange
-import io.github.iltotore.iron.*
+import io.github.iltotore.iron.{zio => _, *}
 import io.github.iltotore.iron.constraint.all.*
 import zio.schema.*
 import zio.schema.annotation.*

--- a/modules/pg/src/main/scala/graviton/pg/RefinedSchemas.scala
+++ b/modules/pg/src/main/scala/graviton/pg/RefinedSchemas.scala
@@ -1,0 +1,3 @@
+package graviton.pg
+
+export graviton.core.refined.given

--- a/modules/s3/src/test/scala/graviton/s3/S3BlobStoreSpec.scala
+++ b/modules/s3/src/test/scala/graviton/s3/S3BlobStoreSpec.scala
@@ -4,7 +4,7 @@ import graviton.*
 import zio.*
 import zio.stream.*
 import zio.test.*
-import io.github.iltotore.iron.*
+import io.github.iltotore.iron.{zio => _, *}
 import io.github.iltotore.iron.constraint.all.*
 import io.minio.{MakeBucketArgs, MinioClient}
 import org.testcontainers.containers.MinIOContainer


### PR DESCRIPTION
## Summary
- provide a shared Schema instance for any iron-refined type and export the givens for core and pg consumers
- tighten block invariants by replacing custom constraints with explicit length checks and a runtime-index constraint
- align iron DbCodec derivation and encryption spec helpers with the new runtime constraints

## Testing
- `./sbt scalafmtAll`
- `./sbt -Dsbt.supershell=false test` *(fails: Testcontainers requires a Docker daemon in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dba76c44f4832e9bc633afdba093b0