### PR TITLE
Refactor block and file storage interfaces

### DIFF
--- a/modules/core/src/main/scala/graviton/core/BlobStore.scala
+++ b/modules/core/src/main/scala/graviton/core/BlobStore.scala
@@ -5,11 +5,11 @@ import zio.stream.*
 
 trait BlobStore extends BlockStore:
   def insertWith(
-    key: BinaryKey.WritableKey
+    key: FileKey.WritableKey
   ): ZSink[Any, Throwable, Byte, Byte, Boolean]
-  def findBinary(key: BinaryKey): IO[Throwable, Option[Bytes]]
-  def copy(from: BinaryKey, to: BinaryKey.WritableKey): IO[Throwable, Unit]
-  override def delete(key: BinaryKey): IO[Throwable, Boolean]
+  def findBinary(key: FileKey): IO[Throwable, Option[Bytes]]
+  def copy(from: FileKey, to: FileKey.WritableKey): IO[Throwable, Unit]
+  override def delete(key: FileKey): IO[Throwable, Boolean]
   def writeWithAttrs(
     provided: BinaryAttributes
-  ): ZSink[Any, Throwable, Byte, Byte, (BinaryKey.CasKey, BinaryAttributes)]
+  ): ZSink[Any, Throwable, Byte, Byte, (FileKey.CasKey, BinaryAttributes)]

--- a/modules/core/src/main/scala/graviton/core/BlockManifest.scala
+++ b/modules/core/src/main/scala/graviton/core/BlockManifest.scala
@@ -1,0 +1,22 @@
+package graviton.core
+
+import zio.schema.{DeriveSchema, Schema}
+
+/**
+ * Ordered manifest describing how to reassemble a file from blocks.
+ */
+final case class BlockManifestEntry(
+  offset: Long,
+  size: Int,
+  block: FileKey.CasKey,
+)
+
+object BlockManifestEntry:
+  given Schema[BlockManifestEntry] = DeriveSchema.gen[BlockManifestEntry]
+
+final case class BlockManifest(
+  entries: Vector[BlockManifestEntry]
+)
+
+object BlockManifest:
+  given Schema[BlockManifest] = DeriveSchema.gen[BlockManifest]

--- a/modules/core/src/main/scala/graviton/core/BlockStore.scala
+++ b/modules/core/src/main/scala/graviton/core/BlockStore.scala
@@ -3,8 +3,8 @@ package graviton.core
 import zio.*
 import zio.stream.*
 
-trait BlockStore extends CasStore:
+trait BlockStore extends FileStore:
   def ingestBlocks(
-    chunker: ZSink[Any, Throwable, Byte, Byte, Chunk[BinaryKey.CasKey]]
-  ): ZSink[Any, Throwable, Byte, Byte, Chunk[BinaryKey.CasKey]]
-  def readBlock(key: BinaryKey.CasKey): IO[Throwable, Option[Bytes]]
+    chunker: ZSink[Any, Throwable, Byte, Byte, Chunk[FileKey.CasKey]]
+  ): ZSink[Any, Throwable, Byte, Byte, Chunk[FileKey.CasKey]]
+  def readBlock(key: FileKey.CasKey): IO[Throwable, Option[Bytes]]

--- a/modules/core/src/main/scala/graviton/core/CasStore.scala
+++ b/modules/core/src/main/scala/graviton/core/CasStore.scala
@@ -4,8 +4,8 @@ import zio.*
 import zio.stream.*
 
 trait CasStore extends KeyedStore:
-  def insert: ZSink[Any, Throwable, Byte, Byte, BinaryKey.CasKey]
-  def findBinary(key: BinaryKey.CasKey): IO[Throwable, Option[Bytes]]
+  def insert: ZSink[Any, Throwable, Byte, Byte, FileKey.CasKey]
+  def findBinary(key: FileKey.CasKey): IO[Throwable, Option[Bytes]]
   def readAttributes(
-    key: BinaryKey.CasKey
+    key: FileKey.CasKey
   ): IO[Throwable, Option[BinaryAttributes]]

--- a/modules/core/src/main/scala/graviton/core/FileKey.scala
+++ b/modules/core/src/main/scala/graviton/core/FileKey.scala
@@ -1,0 +1,12 @@
+package graviton.core
+
+/**
+ * Temporary alias during the rename from BinaryKey -> FileKey.
+ * This keeps downstream code compiling while we migrate interfaces.
+ */
+type FileKey = BinaryKey
+
+object FileKey:
+  // Re-expose key constructors and nested types for ergonomic call sites
+  export BinaryKey.{CasKey, WritableKey}
+  export BinaryKey.WritableKey.{Rnd, Static, Scoped}

--- a/modules/core/src/main/scala/graviton/core/FileStore.scala
+++ b/modules/core/src/main/scala/graviton/core/FileStore.scala
@@ -1,0 +1,13 @@
+package graviton.core
+
+import zio.*
+import zio.stream.*
+
+/**
+ * High-level file-oriented store. Creates a sink that accepts a stream of bytes
+ * and yields a content-addressed `FileKey` together with a `BlockManifest` that
+ * describes how the underlying blocks compose the file.
+ */
+trait FileStore extends KeyedStore:
+  def ingest: ZSink[Any, Throwable, Bytes, Nothing, (FileKey, BlockManifest)]
+  def findBinary(key: FileKey): IO[Throwable, Option[Bytes]]

--- a/modules/core/src/main/scala/graviton/core/KeyedStore.scala
+++ b/modules/core/src/main/scala/graviton/core/KeyedStore.scala
@@ -4,6 +4,6 @@ import zio.*
 import zio.stream.*
 
 trait KeyedStore:
-  def exists(key: BinaryKey): IO[Throwable, Boolean]
-  def delete(key: BinaryKey): IO[Throwable, Boolean]
-  def listKeys(matcher: BinaryKeyMatcher): ZStream[Any, Throwable, BinaryKey]
+  def exists(key: FileKey): IO[Throwable, Boolean]
+  def delete(key: FileKey): IO[Throwable, Boolean]
+  def listKeys(matcher: BinaryKeyMatcher): ZStream[Any, Throwable, FileKey]


### PR DESCRIPTION
Refactor storage interfaces by renaming `BinaryKey` to `FileKey`, introducing `FileStore` and `BlockManifest`, and making `BlockStore` a subtype of `FileStore`.

This change cleans up the storage interfaces as requested, establishing `BlockStore` as a subtype of the new `FileStore` trait, and enabling `FileStore` to ingest bytes and return a `FileKey` and a `BlockManifest`.

---
<a href="https://cursor.com/background-agent?bcId=bc-85ac3b55-2228-4200-b0f9-6b4334899105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85ac3b55-2228-4200-b0f9-6b4334899105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

