### PR TITLE
Add diffson integration and schema helpers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ enablePlugins(
 
 import scala.sys.process.*
 import sbtunidoc.ScalaUnidocPlugin.autoImport._
+import sbt.CrossVersion
 import sbt.io.Path
 import sbt.librarymanagement.Artifact
 
@@ -20,15 +21,17 @@ lazy val zioPreludeV     = "1.0.0-RC41"
 lazy val ironV           = "3.2.0"
 lazy val zioSchemaV      = "1.7.4"
 lazy val zioJsonV        = "0.6.2"
-lazy val zioMetricsV     = "2.4.3"
-lazy val zioCacheV       = "0.2.4"
-lazy val zioRocksdbV     = "0.4.4"
-lazy val zioConfigV      = "4.0.4"
-lazy val zioHttpV        = "3.0.0"
-lazy val testContainersV = "1.19.7"
-lazy val zioLoggingV     = "2.2.4"
-lazy val magnumV         = "2.0.0-M2"
-lazy val postgresV       = "42.7.3"
+lazy val zioMetricsV       = "2.4.3"
+lazy val zioCacheV         = "0.2.4"
+lazy val zioRocksdbV       = "0.4.4"
+lazy val zioConfigV        = "4.0.4"
+lazy val zioHttpV          = "3.0.0"
+lazy val testContainersV   = "1.19.7"
+lazy val zioLoggingV       = "2.2.4"
+lazy val magnumV           = "2.0.0-M2"
+lazy val postgresV         = "42.7.3"
+lazy val diffsonV          = "4.6.1"
+lazy val scalaJsonSchemaV  = "0.7.2"
 
 lazy val generatePgSchemas = taskKey[Seq[java.io.File]](
   "Generate DB schemas and snapshot into modules/pg/src/main/scala/graviton/db"
@@ -143,7 +146,11 @@ lazy val root = (project in file("."))
 lazy val core = project
   .in(file("modules/core"))
   .settings(
-    name := "graviton-core"
+    name := "graviton-core",
+    libraryDependencies ++= Seq(
+      "org.gnieh"           %% "diffson-core" % diffsonV,
+      ("com.github.andyglow" %% "scala-jsonschema-core" % scalaJsonSchemaV).cross(CrossVersion.for3Use2_13),
+    ),
   )
   .settings(commonSettings)
 

--- a/modules/core/src/main/scala/graviton/json/JsonSchemas.scala
+++ b/modules/core/src/main/scala/graviton/json/JsonSchemas.scala
@@ -1,0 +1,25 @@
+package graviton.json
+
+import com.github.andyglow.json.JsonFormatter
+import com.github.andyglow.jsonschema.{AsValue, AsValueBuilder}
+import json.Schema
+import json.schema.Version
+import json.schema.Version.Draft07
+import zio.json.JsonDecoder
+import zio.json.ast.Json
+
+object JsonSchemas:
+
+  private val DefaultSchemaId = "https://graviton.io/schema/anonymous"
+
+  def renderString[T, V <: Version](schema: Schema[T], version: V)(using AsValueBuilder[V]): String =
+    JsonFormatter.format(AsValue.schema(schema, version))
+
+  def renderStringDraft07[T](schema: Schema[T], id: String = DefaultSchemaId): String =
+    renderString(schema, Draft07(id))
+
+  def renderJson[T, V <: Version](schema: Schema[T], version: V)(using AsValueBuilder[V]): Either[String, Json] =
+    JsonDecoder[Json].decodeJson(renderString(schema, version))
+
+  def renderJsonDraft07[T](schema: Schema[T], id: String = DefaultSchemaId): Either[String, Json] =
+    renderJson(schema, Draft07(id))

--- a/modules/core/src/main/scala/graviton/json/ZioJsonPatch.scala
+++ b/modules/core/src/main/scala/graviton/json/ZioJsonPatch.scala
@@ -1,0 +1,68 @@
+package graviton.json
+
+import cats.instances.either.*
+import diffson.*
+import diffson.jsonmergepatch.*
+import diffson.jsonpatch.*
+import diffson.jsonpatch.simplediff.remembering.given
+import zio.*
+import zio.Chunk
+import zio.json.ast.Json
+
+object ZioJsonPatch:
+
+  enum PatchError(message: String) extends Exception(message):
+    case InvalidPatch(details: String) extends PatchError(details)
+    case ApplyFailed(details: String)  extends PatchError(details)
+
+  private def throwableMessage(t: Throwable): String =
+    Option(t.getMessage).filter(_.nonEmpty).getOrElse(t.toString)
+
+  given Jsony[Json] with
+    override def makeObject(fields: Map[String, Json]): Json =
+      Json.Obj(Chunk.fromIterable(fields))
+
+    override def fields(json: Json): Option[Map[String, Json]] =
+      json match
+        case Json.Obj(values) =>
+          val builder = Map.newBuilder[String, Json]
+          values.foreach(builder += _)
+          Some(builder.result())
+        case _                => None
+
+    override def makeArray(values: Vector[Json]): Json =
+      Json.Arr(Chunk.fromIterable(values))
+
+    override def array(json: Json): Option[Vector[Json]] =
+      json match
+        case Json.Arr(values) => Some(values.toVector)
+        case _                => None
+
+    override def Null: Json = Json.Null
+
+    override def eqv(x: Json, y: Json): Boolean = x == y
+
+    override def show(value: Json): String = value.toString
+
+  def diff(original: Json, updated: Json): UIO[JsonPatch[Json]] =
+    ZIO.succeed(diffson.diff(original, updated))
+
+  def applyPatch(document: Json, patch: JsonPatch[Json]): IO[PatchError, Json] =
+    type Attempt[A] = Either[Throwable, A]
+    val attempted: Attempt[Json] = patch[Attempt](document)
+    ZIO.fromEither(
+      attempted.left.map {
+        case err: PatchError => err
+        case other           => PatchError.ApplyFailed(throwableMessage(other))
+      }
+    )
+
+  def applyMergePatch(document: Json, merge: JsonMergePatch[Json]): IO[PatchError, Json] =
+    type Attempt[A] = Either[Throwable, A]
+    val attempted: Attempt[Json] = merge[Attempt](document)
+    ZIO.fromEither(
+      attempted.left.map {
+        case err: PatchError => err
+        case other           => PatchError.ApplyFailed(throwableMessage(other))
+      }
+    )

--- a/modules/core/src/test/scala/graviton/json/JsonSchemasSpec.scala
+++ b/modules/core/src/test/scala/graviton/json/JsonSchemasSpec.scala
@@ -1,0 +1,36 @@
+package graviton.json
+
+import json.Schema
+import json.Schema.`object`
+import json.Schema.`object`.Field
+import zio.json.ast.Json
+import zio.test.*
+
+object JsonSchemasSpec extends ZIOSpecDefault:
+
+  private val sampleSchema =
+    `object`[Unit](
+      Field("id", Schema.`string`[String]),
+      Field("size", Schema.`number`[Long]),
+      Field("mime", Schema.`string`[String]),
+    )
+
+  def spec =
+    suite("JsonSchemas")(
+      test("render Draft07 schema as Json AST with expected properties") {
+        val schemaResult = JsonSchemas.renderJsonDraft07(sampleSchema)
+        val assertion    = schemaResult match
+          case Right(Json.Obj(fields)) =>
+            val root          = fields.toMap
+            val hasObjectType = root.get("type").contains(Json.Str("object"))
+            val propertiesOk  = root.get("properties").exists {
+              case Json.Obj(props) =>
+                val propMap = props.toMap
+                propMap.contains("id") && propMap.contains("size") && propMap.contains("mime")
+              case _               => false
+            }
+            hasObjectType && propertiesOk
+          case _                       => false
+        assertTrue(assertion)
+      }
+    )

--- a/modules/core/src/test/scala/graviton/json/ZioJsonPatchSpec.scala
+++ b/modules/core/src/test/scala/graviton/json/ZioJsonPatchSpec.scala
@@ -1,0 +1,61 @@
+package graviton.json
+
+import diffson.jsonpatch.JsonPatch
+import diffson.jsonpatch.Remove
+import diffson.jsonpointer.Pointer
+import diffson.jsonmergepatch.JsonMergePatch
+import zio.Chunk
+import zio.json.ast.Json
+import zio.test.*
+
+import graviton.json.ZioJsonPatch.given
+
+object ZioJsonPatchSpec extends ZIOSpecDefault:
+
+  private val one   = Json.Num(java.math.BigDecimal.valueOf(1L))
+  private val two   = Json.Num(java.math.BigDecimal.valueOf(2L))
+  private val hello = Json.Str("graviton")
+
+  def spec =
+    suite("ZioJsonPatch")(
+      test("diff followed by apply reproduces the updated document") {
+        val original = Json.Obj(Chunk("name" -> hello, "version" -> one))
+        val updated  = Json.Obj(Chunk("name" -> hello, "version" -> two, "active" -> Json.Bool(true)))
+        for
+          patch  <- ZioJsonPatch.diff(original, updated)
+          result <- ZioJsonPatch.applyPatch(original, patch)
+        yield assertTrue(result == updated)
+      },
+      test("applyPatch surfaces failures when operations cannot be completed") {
+        val document = Json.Obj(Chunk("value" -> one))
+        val patch    = JsonPatch[Json](
+          List(Remove[Json](Pointer.Root / "missing"))
+        )
+        ZioJsonPatch
+          .applyPatch(document, patch)
+          .either
+          .map(result => assert(result)(Assertion.isLeft(Assertion.isSubtype[ZioJsonPatch.PatchError.ApplyFailed](Assertion.anything))))
+      },
+      test("applyMergePatch merges nested objects and scalar values") {
+        val document = Json.Obj(
+          Chunk(
+            "name" -> hello,
+            "meta" -> Json.Obj(Chunk("version" -> one)),
+          )
+        )
+        val merge    = JsonMergePatch.Object[Json](
+          Map(
+            "meta"   -> Json.Obj(Chunk("status" -> Json.Str("stable"))),
+            "active" -> Json.Bool(true),
+          )
+        )
+        val expected = Json.Obj(
+          Chunk(
+            "name"   -> hello,
+            "meta"   -> Json.Obj(Chunk("version" -> one, "status" -> Json.Str("stable"))),
+            "active" -> Json.Bool(true),
+          )
+        )
+        ZioJsonPatch.applyMergePatch(document, merge).map(result => assertTrue(result == expected))
+      },
+    )

--- a/modules/pg/src/test/scala/graviton/pg/StoreRepoSpec.scala
+++ b/modules/pg/src/test/scala/graviton/pg/StoreRepoSpec.scala
@@ -50,7 +50,7 @@ object StoreRepoSpec extends ZIOSpecDefault {
       version = 0L,
     )
   }
-  
+
   override def spec: ZSpec[TestEnvironment & Scope, Any] =
     suite("StoreRepo")(
       test("upsert inserts and updates existing records") {
@@ -77,6 +77,6 @@ object StoreRepoSpec extends ZIOSpecDefault {
           cursor = graviton.db.Cursor.initial.copy(pageSize = 2L)
           rows  <- repo.listActive(Some(cursor)).take(3).runCollect
         } yield assertTrue(rows.length == 3, rows.forall(_.status == StoreStatus.Active))
-      }
+      },
     ).provideShared(storeRepoLayer ++ testEnvironment) @@ onlyIfTestcontainers @@ TestAspect.sequential
 }


### PR DESCRIPTION
## Summary
- add a Jsony adapter for `zio.json.ast.Json` plus helpers to diff and apply patches with Diffson
- add JSON schema rendering utilities that turn scala-jsonschema definitions into ZIO JSON AST
- wire the new core dependencies and cover them with unit tests

## Testing
- TESTCONTAINERS=0 ./sbt scalafmtAll test

------
https://chatgpt.com/codex/tasks/task_b_68ddfb7ac788832e855e17f0b575f905