### PR TITLE
Add locator reverse lookup helpers and coverage

### DIFF
--- a/modules/core/src/main/scala/graviton/blob/BlobLocator.scala
+++ b/modules/core/src/main/scala/graviton/blob/BlobLocator.scala
@@ -1,12 +1,11 @@
 package graviton.blob
 
-import io.github.iltotore.iron.*
-import io.github.iltotore.iron.constraint.all.*
+import graviton.blob.Types.*
 import io.github.iltotore.iron.zioJson.given
 import _root_.zio.json.{DeriveJsonCodec, JsonCodec}
 
 final case class BlobLocator(
-  scheme: String :| Match["[a-z0-9+.-]+"],
+  scheme: LocatorScheme,
   bucket: String,
   path: String,
 ):

--- a/modules/core/src/main/scala/graviton/blob/LocatorStrategy.scala
+++ b/modules/core/src/main/scala/graviton/blob/LocatorStrategy.scala
@@ -1,0 +1,307 @@
+package graviton.blob
+
+import graviton.blob.Types.*
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.Constraint
+import io.github.iltotore.iron.constraint.all.*
+import io.github.iltotore.iron.constraint.numeric
+
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import scala.util.Try
+
+/**
+ * Strategy responsible for deriving deterministic [[BlobLocator]] values
+ * from content identities.
+ */
+trait LocatorStrategy:
+  def iso: LocatorStrategy.Iso
+
+  final def locatorFor(key: BinaryKey): BlobLocator = iso.forward(key)
+
+  final def keyFor(locator: BlobLocator): Either[String, BinaryKey] = iso.reverse(locator)
+
+object LocatorStrategy:
+
+  inline private def refineOrThrow[A, C](value: A)(using Constraint[A, C]): A :| C =
+    value.refineEither[C].fold(err => throw new IllegalArgumentException(err), identity)
+
+  private val DefaultFanOutSegments: NonNegativeInt     = refineOrThrow[Int, numeric.GreaterEqual[0]](2)
+  private val DefaultSegmentLength: PositiveInt         = refineOrThrow[Int, numeric.Greater[0]](2)
+  private val DefaultChunkDirectoryName: PathSegment    =
+    refineOrThrow[String, Match["[^/]+"] & MinLength[1]]("chunks")
+  private val DefaultChunkIndexWidth: PositiveInt       = refineOrThrow[Int, numeric.Greater[0]](8)
+  private val DefaultManifestName: FileSegment          =
+    refineOrThrow[String, Match["[^/]+"] & MinLength[1]]("manifest.json")
+  private val DefaultMonolithicObjectName: FileSegment  =
+    refineOrThrow[String, Match["[^/]+"] & MinLength[1]]("object.bin")
+  private val DefaultPatchLogDirectoryName: PathSegment =
+    refineOrThrow[String, Match["[^/]+"] & MinLength[1]]("manifest.patches")
+
+  /**
+   * Witness that a strategy can translate between [[BinaryKey]] values and
+   * [[BlobLocator]] instances without losing information.
+   */
+  final case class Iso(
+    forward: BinaryKey => BlobLocator,
+    reverse: BlobLocator => Either[String, BinaryKey],
+  )
+
+  /**
+   * Locator strategy that shards blob paths using fixed-length hash
+   * prefixes. By default it emits paths of the form:
+   *
+   * {{code}}
+   * <prefix>/<algo>/<ab>/<cd>/<algo>-<hash>-<size>/
+   * {{/code}}
+   */
+  final case class ShardedByHash(
+    scheme: LocatorScheme,
+    bucket: String,
+    prefix: Option[String] = None,
+    fanOutSegments: NonNegativeInt = DefaultFanOutSegments,
+    segmentLength: PositiveInt = DefaultSegmentLength,
+    includeTerminalSlash: Boolean = true,
+    chunkDirectoryName: PathSegment = DefaultChunkDirectoryName,
+    chunkIndexWidth: PositiveInt = DefaultChunkIndexWidth,
+    manifestName: FileSegment = DefaultManifestName,
+    monolithicObjectName: FileSegment = DefaultMonolithicObjectName,
+    patchLogDirectoryName: PathSegment = DefaultPatchLogDirectoryName,
+  ) extends LocatorStrategy:
+
+    private val base64MimeEncoder = Base64.getUrlEncoder.withoutPadding()
+    private val base64MimeDecoder = Base64.getUrlDecoder
+
+    private val configuredPrefixSegments =
+      prefix
+        .filter(_.nonEmpty)
+        .map(trimSlashes)
+        .toList
+        .flatMap(_.split('/').iterator.filter(_.nonEmpty).toList)
+
+    override val iso: Iso =
+      Iso(
+        forward = key => BlobLocator(scheme, bucket, locatorPath(key)),
+        reverse = locator => keyFrom(locator),
+      )
+
+    def locatorPath(key: BinaryKey): String =
+      val base = basePath(key)
+      if includeTerminalSlash then ensureTrailingSlash(base) else base
+
+    def rootDirectoryPath(key: BinaryKey): String =
+      ensureTrailingSlash(basePath(key))
+
+    def manifestPath(key: BinaryKey): String =
+      joinFile(rootDirectoryPath(key), manifestName)
+
+    def monolithicObjectPath(key: BinaryKey): String =
+      joinFile(rootDirectoryPath(key), monolithicObjectName)
+
+    def patchLogDirectoryPath(key: BinaryKey): String =
+      joinDirectory(rootDirectoryPath(key), patchLogDirectoryName)
+
+    def chunkDirectoryPath(key: BinaryKey): String =
+      joinDirectory(rootDirectoryPath(key), chunkDirectoryName)
+
+    def chunkPath(key: BinaryKey, index: ChunkIndex): String =
+      val chunkFile = formatChunkIndex(index)
+      joinFile(chunkDirectoryPath(key), chunkFile)
+
+    private def trimSlashes(value: String): String =
+      value.split('/').iterator.filter(_.nonEmpty).mkString("/")
+
+    private def basePath(key: BinaryKey): String =
+      val sanitizedPrefix = prefix.filter(_.nonEmpty).map(trimSlashes)
+      val shardSegments   = shardPieces(key.hash, fanOutSegments, segmentLength)
+      val terminal        = terminalSegment(key)
+      val components      =
+        sanitizedPrefix.toList ++ List(key.algo) ++ shardSegments ++ List(terminal)
+      components.filter(_.nonEmpty).mkString("/")
+
+    private def ensureTrailingSlash(path: String): String =
+      if path.endsWith("/") then path else s"$path/"
+
+    private def joinDirectory(root: String, child: String): String =
+      val trimmed = trimSlashes(child)
+      ensureTrailingSlash(s"${ensureTrailingSlash(root)}$trimmed")
+
+    private def joinFile(root: String, child: String): String =
+      val trimmed = trimSlashes(child)
+      s"${ensureTrailingSlash(root)}$trimmed"
+
+    private def shardPieces(hash: String, segments: Int, length: Int): List[String] =
+      List.tabulate(segments)(identity).flatMap { idx =>
+        val start = idx * length
+        if start >= hash.length then None
+        else
+          val end   = math.min(start + length, hash.length)
+          val slice = hash.substring(start, end)
+          Option.when(slice.nonEmpty)(slice)
+      }
+
+    private def formatChunkIndex(index: ChunkIndex): String =
+      val pattern = s"%0${chunkIndexWidth}d"
+      pattern.format(index: Long)
+
+    private def terminalSegment(key: BinaryKey): String =
+      val base = s"${key.algo}-${key.hash}-${key.size}"
+      key.mime match
+        case Some(mimeValue) =>
+          val encoded = encodeMime(mimeValue)
+          s"$base~$encoded"
+        case None            => base
+
+    private def encodeMime(mime: Mime): String =
+      base64MimeEncoder.encodeToString(mime.getBytes(StandardCharsets.UTF_8)).replace("=", "")
+
+    private def decodeMime(value: String): Either[String, Mime] =
+      val padded =
+        value.length % 4 match
+          case 2 => s"$value=="
+          case 3 => s"$value="
+          case 0 => value
+          case _ => s"$value==="
+
+      Try(String(base64MimeDecoder.decode(padded), StandardCharsets.UTF_8)).toEither.left
+        .map(_.getMessage)
+        .flatMap(_.refineEither[Match["[a-z0-9!#$&^_.+-]+/[a-z0-9!#$&^_.+-]+(;.*)?"]])
+
+    private def componentsOf(path: String): List[String] =
+      trimSlashes(path).split('/').iterator.filter(_.nonEmpty).toList
+
+    private def dropConfiguredPrefix(components: List[String]): Either[String, List[String]] =
+      configuredPrefixSegments.foldLeft[Either[String, List[String]]](Right(components)) { case (acc, segment) =>
+        acc.flatMap {
+          case head :: tail if head == segment => Right(tail)
+          case _                               => Left(s"Locator path missing expected prefix segment '$segment'")
+        }
+      }
+
+    def keyFromLocatorPath(path: String): Either[String, BinaryKey] =
+      keyFromSegments(componentsOf(path))
+
+    def keyFromRootDirectoryPath(path: String): Either[String, BinaryKey] =
+      keyFromLocatorPath(path)
+
+    def keyFromManifestPath(path: String): Either[String, BinaryKey] =
+      for
+        segments <- ensureTerminalSegment(path, manifestName)
+        key      <- keyFromSegments(segments)
+      yield key
+
+    def keyFromMonolithicObjectPath(path: String): Either[String, BinaryKey] =
+      for
+        segments <- ensureTerminalSegment(path, monolithicObjectName)
+        key      <- keyFromSegments(segments)
+      yield key
+
+    def keyFromPatchLogDirectoryPath(path: String): Either[String, BinaryKey] =
+      for
+        segments <- ensureTerminalSegment(path, patchLogDirectoryName)
+        key      <- keyFromSegments(segments)
+      yield key
+
+    def keyFromChunkDirectoryPath(path: String): Either[String, BinaryKey] =
+      for
+        segments <- ensureTerminalSegment(path, chunkDirectoryName)
+        key      <- keyFromSegments(segments)
+      yield key
+
+    def keyAndChunkIndexFromPath(path: String): Either[String, (BinaryKey, ChunkIndex)] =
+      val segments = componentsOf(path)
+      for
+        chunkFile      <- segments.lastOption.toRight("Chunk path missing chunk file")
+        beforeFile      = segments.dropRight(1)
+        chunkDirectory <- beforeFile.lastOption.toRight("Chunk path missing chunk directory")
+        _              <- Either.cond(
+                            chunkDirectory == chunkDirectoryName,
+                            (),
+                            s"Chunk path expected directory '$chunkDirectoryName' but found '$chunkDirectory'",
+                          )
+        locatorSegments = beforeFile.dropRight(1)
+        index          <-
+          chunkFile
+            .refineEither[Match["[0-9]+"]]
+            .flatMap(value => value.toLongOption.toRight(s"Chunk file '$chunkFile' was not a valid Long"))
+            .flatMap(_.refineEither[numeric.Greater[-1]])
+        key            <- keyFromSegments(locatorSegments)
+      yield key -> index
+
+    private def keyFrom(locator: BlobLocator): Either[String, BinaryKey] =
+      for
+        _   <- Either.cond(locator.scheme == scheme, (), s"Unexpected locator scheme '${locator.scheme}'")
+        _   <- Either.cond(locator.bucket == bucket, (), s"Unexpected locator bucket '${locator.bucket}'")
+        key <- keyFromSegments(componentsOf(locator.path))
+      yield key
+
+    private def keyFromSegments(segments: List[String]): Either[String, BinaryKey] =
+      for
+        remaining <- dropConfiguredPrefix(segments)
+        algoPart  <- remaining.headOption.toRight("Locator path did not contain an algorithm segment")
+        tail       = remaining.drop(1)
+        terminal  <- tail.lastOption.toRight("Locator path missing terminal segment")
+        shards     = tail.dropRight(1)
+        identity  <- parseTerminal(terminal)
+        _         <- Either.cond(
+                       identity.algo == algoPart,
+                       (),
+                       s"Terminal segment algorithm '${identity.algo}' mismatched '$algoPart'",
+                     )
+        _         <- Either.cond(
+                       shards == shardPieces(identity.hash, fanOutSegments, segmentLength),
+                       (),
+                       "Locator shards did not match hash fan-out",
+                     )
+        key       <- BinaryKey.make(identity.algo, identity.hash, identity.size, identity.mime)
+      yield key
+
+    private def ensureTerminalSegment(path: String, expected: String): Either[String, List[String]] =
+      val segments = componentsOf(path)
+      for
+        last <- segments.lastOption.toRight(s"Path '$path' did not contain any segments")
+        _    <- Either.cond(
+                  last == expected,
+                  (),
+                  s"Path '$path' did not end with expected segment '$expected'",
+                )
+      yield segments.dropRight(1)
+
+    private final case class ParsedTerminal(algo: Algo, hash: HexLower, size: Size, mime: Option[Mime])
+
+    private def parseTerminal(segment: String): Either[String, ParsedTerminal] =
+      val split                       = segment.split("~", 2).toList
+      val (identityPart, mimeEncoded) =
+        split match
+          case head :: encoded :: Nil => head -> Some(encoded)
+          case head :: encoded :: _   => head -> Some(encoded)
+          case head :: Nil            => head -> None
+          case Nil                    => ""   -> None
+
+      val lastDash = identityPart.lastIndexOf('-')
+      if lastDash <= 0 || lastDash == identityPart.length - 1 then
+        Left(s"Terminal segment '$segment' did not contain a valid size component")
+      else
+        val sizePart   = identityPart.substring(lastDash + 1)
+        val beforeSize = identityPart.substring(0, lastDash)
+        val hashDash   = beforeSize.lastIndexOf('-')
+        if hashDash <= 0 || hashDash == beforeSize.length - 1 then
+          Left(s"Terminal segment '$segment' did not contain a valid hash component")
+        else
+          val algoPart = beforeSize.substring(0, hashDash)
+          val hashPart = beforeSize.substring(hashDash + 1)
+          for
+            algo <- algoPart.refineEither[Match["(sha-256|blake3|md5)"]]
+            hash <- hashPart.refineEither[Match["[0-9a-f]+"] & MinLength[2]]
+            size <-
+              sizePart.toLongOption
+                .toRight(s"Terminal segment size '$sizePart' was not a valid Long")
+                .flatMap(_.refineEither[numeric.Greater[-1]])
+            mime <- mimeEncoded
+                      .map(decodeMime)
+                      .map(_.map(Some(_)))
+                      .getOrElse(Right(None))
+          yield ParsedTerminal(algo, hash, size, mime)
+
+  val default: LocatorStrategy =
+    ShardedByHash(scheme = "file", bucket = "", prefix = None)

--- a/modules/core/src/main/scala/graviton/blob/ObjectStoreTransport.scala
+++ b/modules/core/src/main/scala/graviton/blob/ObjectStoreTransport.scala
@@ -1,0 +1,19 @@
+package graviton.blob
+
+import zio.*
+import zio.stream.*
+
+import java.io.IOException
+
+trait ObjectStoreTransport:
+  def head(bucket: String, path: String): IO[IOException, Option[(Long, Option[String])]]
+  def list(bucket: String, prefix: String): ZStream[Any, IOException, String]
+  def get(
+    bucket: String,
+    path: String,
+    range: Option[(Long, Long)] = None,
+  ): ZStream[Any, IOException, Byte]
+  def put(bucket: String, path: String): ZSink[Any, IOException, Byte, Nothing, Unit]
+  def putMultipart(bucket: String, path: String, minPart: Int): ZSink[Any, IOException, Byte, Nothing, Unit]
+  def delete(bucket: String, path: String): IO[IOException, Unit]
+  def copy(srcBucket: String, srcPath: String, dstBucket: String, dstPath: String): IO[IOException, Unit]

--- a/modules/core/src/main/scala/graviton/blob/StorePolicy.scala
+++ b/modules/core/src/main/scala/graviton/blob/StorePolicy.scala
@@ -1,0 +1,36 @@
+package graviton.blob
+
+import _root_.zio.json.{DeriveJsonCodec, JsonCodec}
+
+enum BlobLayout derives JsonCodec:
+  case FramedManifestChunks
+  case MonolithicObject
+
+final case class StorePolicy(
+  layout: BlobLayout,
+  minPartSize: Int = StorePolicy.DefaultMinPartSize,
+):
+  require(minPartSize > 0, "minPartSize must be positive")
+
+object StorePolicy:
+  val DefaultMinPartSize: Int  = 5 * 1024 * 1024
+  given JsonCodec[StorePolicy] = DeriveJsonCodec.gen[StorePolicy]
+
+trait PolicyResolver:
+  def policyFor(scheme: String): StorePolicy
+
+object PolicyResolver:
+  final case class Static(
+    overrides: Map[String, StorePolicy],
+    fallback: StorePolicy,
+  ) extends PolicyResolver:
+    override def policyFor(scheme: String): StorePolicy =
+      overrides.getOrElse(scheme, fallback)
+
+  val default: PolicyResolver = Static(
+    overrides = Map(
+      "file" -> StorePolicy(BlobLayout.FramedManifestChunks),
+      "s3"   -> StorePolicy(BlobLayout.FramedManifestChunks),
+    ),
+    fallback = StorePolicy(BlobLayout.FramedManifestChunks),
+  )

--- a/modules/core/src/main/scala/graviton/blob/Types.scala
+++ b/modules/core/src/main/scala/graviton/blob/Types.scala
@@ -10,13 +10,18 @@ import _root_.zio.json.*
  * Iron refined aliases used throughout the blob model.
  */
 object Types:
-  type Algo       = String :| Match["(sha-256|blake3|md5)"]
-  type HexLower   = String :| (Match["[0-9a-f]+"] & MinLength[2])
-  type Mime       = String :| Match["[a-z0-9!#$&^_.+-]+/[a-z0-9!#$&^_.+-]+(;.*)?"]
-  type Size       = Long :| numeric.Greater[-1]
-  type ChunkSize  = Int :| numeric.Greater[0]
-  type ChunkIndex = Long :| numeric.Greater[-1]
-  type ChunkCount = Long :| numeric.Greater[-1]
+  type Algo           = String :| Match["(sha-256|blake3|md5)"]
+  type HexLower       = String :| (Match["[0-9a-f]+"] & MinLength[2])
+  type Mime           = String :| Match["[a-z0-9!#$&^_.+-]+/[a-z0-9!#$&^_.+-]+(;.*)?"]
+  type Size           = Long :| numeric.Greater[-1]
+  type ChunkSize      = Int :| numeric.Greater[0]
+  type ChunkIndex     = Long :| numeric.Greater[-1]
+  type ChunkCount     = Long :| numeric.Greater[-1]
+  type LocatorScheme  = String :| Match["[a-z0-9+.-]+"]
+  type NonNegativeInt = Int :| numeric.GreaterEqual[0]
+  type PositiveInt    = Int :| numeric.Greater[0]
+  type PathSegment    = String :| (Match["[^/]+"] & MinLength[1])
+  type FileSegment    = String :| (Match["[^/]+"] & MinLength[1])
 
   inline private def codecRefined[A, C](using JsonCodec[A], Constraint[A, C]): JsonCodec[A :| C] =
     summon[JsonCodec[A]].transformOrFail(
@@ -24,13 +29,18 @@ object Types:
       refined => refined.asInstanceOf[A],
     )
 
-  given JsonCodec[Algo]       = codecRefined[String, Match["(sha-256|blake3|md5)"]]
-  given JsonCodec[HexLower]   = codecRefined[String, Match["[0-9a-f]+"] & MinLength[2]]
-  given JsonCodec[Mime]       = codecRefined[String, Match["[a-z0-9!#$&^_.+-]+/[a-z0-9!#$&^_.+-]+(;.*)?"]]
-  given JsonCodec[Size]       = codecRefined[Long, numeric.Greater[-1]]
-  given JsonCodec[ChunkSize]  = codecRefined[Int, numeric.Greater[0]]
-  given JsonCodec[ChunkIndex] = codecRefined[Long, numeric.Greater[-1]]
-  given JsonCodec[ChunkCount] = codecRefined[Long, numeric.Greater[-1]]
+  given JsonCodec[Algo]           = codecRefined[String, Match["(sha-256|blake3|md5)"]]
+  given JsonCodec[HexLower]       = codecRefined[String, Match["[0-9a-f]+"] & MinLength[2]]
+  given JsonCodec[Mime]           = codecRefined[String, Match["[a-z0-9!#$&^_.+-]+/[a-z0-9!#$&^_.+-]+(;.*)?"]]
+  given JsonCodec[Size]           = codecRefined[Long, numeric.Greater[-1]]
+  given JsonCodec[ChunkSize]      = codecRefined[Int, numeric.Greater[0]]
+  given JsonCodec[ChunkIndex]     = codecRefined[Long, numeric.Greater[-1]]
+  given JsonCodec[ChunkCount]     = codecRefined[Long, numeric.Greater[-1]]
+  given JsonCodec[LocatorScheme]  = codecRefined[String, Match["[a-z0-9+.-]+"]]
+  given JsonCodec[NonNegativeInt] = codecRefined[Int, numeric.GreaterEqual[0]]
+  given JsonCodec[PositiveInt]    = codecRefined[Int, numeric.Greater[0]]
+  given JsonCodec[PathSegment]    = codecRefined[String, Match["[^/]+"] & MinLength[1]]
+  given JsonCodec[FileSegment]    = codecRefined[String, Match["[^/]+"] & MinLength[1]]
 
   private val Sha256HexLength = 64
   private val Md5HexLength    = 32

--- a/modules/core/src/test/scala/graviton/blob/LocatorStrategySpec.scala
+++ b/modules/core/src/test/scala/graviton/blob/LocatorStrategySpec.scala
@@ -1,0 +1,238 @@
+package graviton.blob
+
+import graviton.blob.Types.*
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.Constraint
+import io.github.iltotore.iron.constraint.all.*
+import io.github.iltotore.iron.constraint.numeric
+import _root_.zio.test.*
+
+object LocatorStrategySpec extends ZIOSpecDefault:
+  inline private def refineOrThrow[A, C](value: A)(using Constraint[A, C]): A :| C =
+    value.refineEither[C].fold(err => throw new IllegalArgumentException(err), identity)
+
+  private def algoOf(value: String): Algo                  = refineOrThrow[String, Match["(sha-256|blake3|md5)"]](value)
+  private def hexOf(value: String): HexLower               = refineOrThrow[String, Match["[0-9a-f]+"] & MinLength[2]](value)
+  private def sizeOf(value: Long): Size                    = refineOrThrow[Long, numeric.Greater[-1]](value)
+  private def chunkIndexOf(value: Long): ChunkIndex        = refineOrThrow[Long, numeric.Greater[-1]](value)
+  private def mimeOf(value: String): Mime                  =
+    refineOrThrow[String, Match["[a-z0-9!#$&^_.+-]+/[a-z0-9!#$&^_.+-]+(;.*)?"]](value)
+  private def nonNegativeIntOf(value: Int): NonNegativeInt = refineOrThrow[Int, numeric.GreaterEqual[0]](value)
+  private def positiveIntOf(value: Int): PositiveInt       = refineOrThrow[Int, numeric.Greater[0]](value)
+  private def pathSegmentOf(value: String): PathSegment    =
+    refineOrThrow[String, Match["[^/]+"] & MinLength[1]](value)
+
+  private val sha256String     = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  private val sha256: HexLower =
+    hexOf(sha256String)
+
+  private val key = BinaryKey
+    .make(algoOf("sha-256"), sha256, sizeOf(1024L), Some(mimeOf("application/octet-stream")))
+    .fold(err => throw new RuntimeException(err), identity)
+
+  private def keyOf(algo: String, hash: String, size: Long, mime: Option[String]): BinaryKey =
+    BinaryKey
+      .make(algoOf(algo), hexOf(hash), sizeOf(size), mime.map(mimeOf))
+      .fold(err => throw new RuntimeException(err), identity)
+
+  def spec =
+    suite("LocatorStrategy")(
+      test("ShardedByHash derives deterministic paths") {
+        val strategy = LocatorStrategy.ShardedByHash(
+          scheme = "s3",
+          bucket = "example",
+          prefix = Some("blobs"),
+        )
+
+        val locator = strategy.locatorFor(key)
+        assertTrue(
+          locator.scheme == "s3",
+          locator.bucket == "example",
+          locator.path ==
+            "blobs/sha-256/01/23/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/",
+          strategy.manifestPath(key) ==
+            "blobs/sha-256/01/23/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/manifest.json",
+          strategy.chunkPath(key, chunkIndexOf(0L)) ==
+            "blobs/sha-256/01/23/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/chunks/00000000",
+          strategy.chunkDirectoryPath(key) ==
+            "blobs/sha-256/01/23/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/chunks/",
+        )
+      },
+      test("ShardedByHash tolerates missing prefix and short shards") {
+        val smallKey     = keyOf("blake3", "0a", 0L, None)
+        val strategy     = LocatorStrategy.ShardedByHash(
+          scheme = "file",
+          bucket = "", // e.g. filesystem root
+          prefix = None,
+          fanOutSegments = nonNegativeIntOf(3),
+          segmentLength = positiveIntOf(2),
+        )
+        val locator      = strategy.locatorFor(smallKey)
+        val roundTripped = strategy.keyFor(locator).toOption
+        assertTrue(
+          locator.path == "blake3/0a/blake3-0a-0/",
+          strategy.monolithicObjectPath(smallKey) == "blake3/0a/blake3-0a-0/object.bin",
+          roundTripped.contains(smallKey),
+        )
+      },
+      test("ShardedByHash trims user-supplied prefixes and supports directories") {
+        val strategy = LocatorStrategy.ShardedByHash(
+          scheme = "file",
+          bucket = "",
+          prefix = Some("/deep//nest/"),
+          fanOutSegments = nonNegativeIntOf(0),
+          includeTerminalSlash = false,
+          patchLogDirectoryName = pathSegmentOf("patches"),
+        )
+
+        val locator = strategy.locatorFor(key)
+        assertTrue(
+          locator.path ==
+            "deep/nest/sha-256/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt",
+          strategy.rootDirectoryPath(key) ==
+            "deep/nest/sha-256/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/",
+          strategy.patchLogDirectoryPath(key) ==
+            "deep/nest/sha-256/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/patches/",
+          strategy.chunkDirectoryPath(key) ==
+            "deep/nest/sha-256/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/chunks/",
+        )
+      },
+      test("ShardedByHash formats chunk indices with configurable width") {
+        val strategy = LocatorStrategy.ShardedByHash(
+          scheme = "s3",
+          bucket = "example",
+          chunkIndexWidth = positiveIntOf(4),
+        )
+
+        val formatted = List(
+          strategy.chunkPath(key, chunkIndexOf(0L)),
+          strategy.chunkPath(key, chunkIndexOf(1L)),
+          strategy.chunkPath(key, chunkIndexOf(12L)),
+          strategy.chunkPath(key, chunkIndexOf(9999L)),
+        )
+        assertTrue(
+          formatted == List(
+            "sha-256/01/23/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/chunks/0000",
+            "sha-256/01/23/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/chunks/0001",
+            "sha-256/01/23/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/chunks/0012",
+            "sha-256/01/23/sha-256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef-1024~YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFt/chunks/9999",
+          )
+        )
+      },
+      test("ShardedByHash does not emit shard segments when fan-out is zero") {
+        val strategy = LocatorStrategy.ShardedByHash(
+          scheme = "s3",
+          bucket = "example",
+          fanOutSegments = nonNegativeIntOf(0),
+        )
+
+        val locator = strategy.locatorFor(key)
+        assertTrue(
+          locator.path.startsWith("sha-256/"),
+          !locator.path.contains("/01/"),
+        )
+      },
+      test("ShardedByHash respects includeTerminalSlash flag") {
+        val noSlash   = LocatorStrategy.ShardedByHash(
+          scheme = "s3",
+          bucket = "example",
+          includeTerminalSlash = false,
+        )
+        val withSlash = LocatorStrategy.ShardedByHash(
+          scheme = "s3",
+          bucket = "example",
+          includeTerminalSlash = true,
+        )
+
+        assertTrue(
+          !noSlash.locatorFor(key).path.endsWith("/"),
+          withSlash.locatorFor(key).path.endsWith("/"),
+        )
+      },
+      test("ShardedByHash rejects invalid configuration") {
+        val badSegmentLength = 0.refineEither[numeric.Greater[0]]
+        val badFanOut        = (-1).refineEither[numeric.GreaterEqual[0]]
+        val badDirectory     = "".refineEither[Match["[^/]+"] & MinLength[1]]
+
+        assertTrue(badSegmentLength.isLeft, badFanOut.isLeft, badDirectory.isLeft)
+      },
+      test("ShardedByHash iso reconstructs keys with and without MIME metadata") {
+        val baseStrategy = LocatorStrategy.ShardedByHash(
+          scheme = "s3",
+          bucket = "example",
+          includeTerminalSlash = false,
+        )
+        val withoutMime  = keyOf("sha-256", sha256String, 1024L, None)
+        val withMime     = key
+
+        val locatorNoMime = baseStrategy.locatorFor(withoutMime)
+        val locatorMime   = baseStrategy.locatorFor(withMime)
+
+        assertTrue(
+          baseStrategy.keyFor(locatorNoMime).contains(withoutMime),
+          baseStrategy.keyFor(locatorMime).contains(withMime),
+        )
+      },
+      test("ShardedByHash iso validates locator affinity") {
+        val strategy = LocatorStrategy.ShardedByHash(
+          scheme = "s3",
+          bucket = "example",
+          prefix = Some("tenant"),
+        )
+        val locator  = strategy.locatorFor(key)
+
+        val wrongScheme = locator.copy(scheme = "file")
+        val wrongBucket = locator.copy(bucket = "other")
+        val wrongPath   = locator.copy(path = s"tenant/${key.algo}/aa/bb/terminal")
+
+        assertTrue(
+          strategy.keyFor(locator).contains(key),
+          strategy.keyFor(wrongScheme).isLeft,
+          strategy.keyFor(wrongBucket).isLeft,
+          strategy.keyFor(wrongPath).isLeft,
+        )
+      },
+      test("ShardedByHash extracts keys from derived paths") {
+        val strategy = LocatorStrategy.ShardedByHash(
+          scheme = "s3",
+          bucket = "example",
+          prefix = Some("tenant"),
+        )
+        val locator  = strategy.locatorFor(key)
+        val root     = strategy.rootDirectoryPath(key)
+        val manifest = strategy.manifestPath(key)
+        val mono     = strategy.monolithicObjectPath(key)
+        val patchDir = strategy.patchLogDirectoryPath(key)
+        val chunkDir = strategy.chunkDirectoryPath(key)
+        val chunk0   = strategy.chunkPath(key, chunkIndexOf(0L))
+
+        assertTrue(
+          strategy.keyFromLocatorPath(locator.path).contains(key),
+          strategy.keyFromRootDirectoryPath(root).contains(key),
+          strategy.keyFromManifestPath(manifest).contains(key),
+          strategy.keyFromMonolithicObjectPath(mono).contains(key),
+          strategy.keyFromPatchLogDirectoryPath(patchDir).contains(key),
+          strategy.keyFromChunkDirectoryPath(chunkDir).contains(key),
+          strategy.keyAndChunkIndexFromPath(chunk0).contains((key, chunkIndexOf(0L))),
+        )
+      },
+      test("ShardedByHash chunk parsing validates directory and index") {
+        val strategy      = LocatorStrategy.ShardedByHash(
+          scheme = "s3",
+          bucket = "example",
+          chunkIndexWidth = positiveIntOf(2),
+        )
+        val chunkPath     = strategy.chunkPath(key, chunkIndexOf(10L))
+        val wrongDirPath  = chunkPath.replace("chunks", "parts")
+        val prefixEnd     = chunkPath.lastIndexOf('/')
+        val wrongFilePath =
+          if prefixEnd >= 0 then s"${chunkPath.substring(0, prefixEnd + 1)}xx"
+          else "xx"
+
+        assertTrue(
+          strategy.keyAndChunkIndexFromPath(chunkPath).contains((key, chunkIndexOf(10L))),
+          strategy.keyAndChunkIndexFromPath(wrongDirPath).isLeft,
+          strategy.keyAndChunkIndexFromPath(wrongFilePath).isLeft,
+        )
+      },
+    )

--- a/modules/core/src/test/scala/graviton/blob/StorePolicySpec.scala
+++ b/modules/core/src/test/scala/graviton/blob/StorePolicySpec.scala
@@ -1,0 +1,47 @@
+package graviton.blob
+
+import zio.test.*
+import zio.json.*
+
+object StorePolicySpec extends ZIOSpecDefault:
+  def spec =
+    suite("StorePolicy")(
+      test("rejects non-positive multipart thresholds") {
+        assertTrue(
+          scala.util.Try(StorePolicy(BlobLayout.FramedManifestChunks, minPartSize = 0)).isFailure,
+          scala.util.Try(StorePolicy(BlobLayout.FramedManifestChunks, minPartSize = -1)).isFailure,
+        )
+      },
+      test("PolicyResolver.Static respects overrides and fallback") {
+        val resolver = PolicyResolver.Static(
+          overrides = Map("s3" -> StorePolicy(BlobLayout.MonolithicObject, minPartSize = 8 * 1024 * 1024)),
+          fallback = StorePolicy(BlobLayout.FramedManifestChunks),
+        )
+        val s3Policy = resolver.policyFor("s3")
+        val fsPolicy = resolver.policyFor("file")
+        assertTrue(
+          s3Policy.layout == BlobLayout.MonolithicObject,
+          s3Policy.minPartSize == 8 * 1024 * 1024,
+          fsPolicy.layout == BlobLayout.FramedManifestChunks,
+        )
+      },
+      test("PolicyResolver.default provides sensible defaults") {
+        val resolver = PolicyResolver.default
+        assertTrue(
+          resolver.policyFor("file").layout == BlobLayout.FramedManifestChunks,
+          resolver.policyFor("s3").minPartSize == StorePolicy.DefaultMinPartSize,
+          resolver.policyFor("gcs").layout == BlobLayout.FramedManifestChunks,
+        )
+      },
+      test("StorePolicy JSON codec round-trips") {
+        val policy  = StorePolicy(BlobLayout.MonolithicObject, minPartSize = 10)
+        val json    = policy.toJson
+        val decoded = json.fromJson[StorePolicy]
+        assertTrue(decoded == Right(policy))
+      },
+      test("BlobLayout JSON codec round-trips values") {
+        val encoded = BlobLayout.FramedManifestChunks.toJson
+        val decoded = encoded.fromJson[BlobLayout]
+        assertTrue(decoded == Right(BlobLayout.FramedManifestChunks))
+      },
+    )


### PR DESCRIPTION
## Summary
- expose helper methods on the sharded locator strategy to recover binary keys from manifest, chunk, and other derived paths
- extend the locator strategy specs with assertions over the new reverse lookups and chunk index validation scenarios

## Testing
- TESTCONTAINERS=0 ./sbt scalafmtAll test

------
https://chatgpt.com/codex/tasks/task_b_68de0db0ad30832eaec1dec29c1b5ad5