### PR TITLE
Allow ZStreamDecoder.once to emit without consuming bits

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ lazy val zioLoggingV       = "2.2.4"
 lazy val magnumV           = "2.0.0-M2"
 lazy val postgresV         = "42.7.3"
 lazy val diffsonV          = "4.6.1"
+lazy val scodecV           = "2.3.3"
 lazy val scalaJsonSchemaV  = "0.7.2"
 lazy val catsCollectionsV  = "0.9.10"
 
@@ -152,7 +153,8 @@ lazy val core = project
     libraryDependencies ++= Seq(
       "org.gnieh"           %% "diffson-core" % diffsonV,
       ("com.github.andyglow" %% "scala-jsonschema-core" % scalaJsonSchemaV).cross(CrossVersion.for3Use2_13),
-      "org.typelevel"       %% "cats-collections-core"   % catsCollectionsV,
+    "org.typelevel"       %% "cats-collections-core"   % catsCollectionsV,
+    "org.scodec"          %% "scodec-core"             % scodecV,
     ),
   )
   .settings(commonSettings)

--- a/modules/core/src/main/scala/graviton/interop/scodec/ZStreamDecoder.scala
+++ b/modules/core/src/main/scala/graviton/interop/scodec/ZStreamDecoder.scala
@@ -1,0 +1,185 @@
+package graviton.interop.scodec
+
+import zio._
+import zio.stream._
+import zio.ChunkBuilder
+import zio.prelude.fx.ZPure
+import _root_.scodec.{Attempt, DecodeResult, Decoder, Err}
+import _root_.scodec.bits.BitVector
+
+/** A simple error wrapper used when a scodec decoder fails. */
+final case class CodecError(err: Err) extends Exception(err.messageWithContext)
+
+/**
+ * Utilities for decoding binary data using scodec within ZIO streams.
+ *
+ * The API mirrors a subset of fs2's `StreamDecoder` helpers and focuses on
+ * two decoding modes: [[once]] for decoding a single value and [[many]] for
+ * repeatedly decoding values. Each mode has a lenient variant ([[tryOnce]] and
+ * [[tryMany]]) that swallows unrecoverable errors and terminates the stream
+ * gracefully.
+ */
+object ZStreamDecoder {
+
+  /** Decode at most one value from the incoming stream, failing on errors. */
+  def once[A](decoder: Decoder[A]): ZPipeline[Any, Throwable, BitVector, A] =
+    decode(decoder, once = true, failOnError = true)
+
+  /** Decode values repeatedly from the incoming stream, failing on errors. */
+  def many[A](decoder: Decoder[A]): ZPipeline[Any, Throwable, BitVector, A] =
+    decode(decoder, once = false, failOnError = true)
+
+  /**
+   * Decode at most one value from the incoming stream. Unrecoverable errors are
+   * swallowed and terminate the pipeline.
+   */
+  def tryOnce[A](decoder: Decoder[A]): ZPipeline[Any, Throwable, BitVector, A] =
+    decode(decoder, once = true, failOnError = false)
+
+  /**
+   * Decode values repeatedly from the incoming stream. Unrecoverable errors are
+   * swallowed and terminate the pipeline.
+   */
+  def tryMany[A](decoder: Decoder[A]): ZPipeline[Any, Throwable, BitVector, A] =
+    decode(decoder, once = false, failOnError = false)
+
+  private final case class DecoderState(
+    buffer: BitVector,
+    awaiting: Option[Err.InsufficientBits],
+  )
+
+  private object DecoderState {
+    val empty: DecoderState = DecoderState(BitVector.empty, None)
+  }
+
+  private final case class StepOutcome[A](values: Chunk[A], stop: Boolean)
+
+  private def decode[A](
+    decoder: Decoder[A],
+    once: Boolean,
+    failOnError: Boolean,
+  ): ZPipeline[Any, Throwable, BitVector, A] = {
+    def loop(
+      state: DecoderState
+    ): ZChannel[Any, Throwable, Chunk[BitVector], Any, Throwable, Chunk[A], Unit] =
+      ZChannel.readWith(
+        chunk =>
+          processChunk(decoder, once, failOnError)(chunk, state) match {
+            case Left(err)                   => ZChannel.fail(err)
+            case Right((nextState, outcome)) =>
+              val emit =
+                if (outcome.values.isEmpty) ZChannel.unit
+                else ZChannel.write(outcome.values)
+              if (outcome.stop) emit
+              else emit *> loop(nextState)
+          },
+        err => ZChannel.fail(err),
+        _ => ZChannel.unit,
+      )
+
+    ZPipeline.fromChannel(loop(DecoderState.empty))
+  }
+
+  private def processChunk[A](
+    decoder: Decoder[A],
+    once: Boolean,
+    failOnError: Boolean,
+  )(
+    chunk: Chunk[BitVector],
+    state: DecoderState,
+  ): Either[CodecError, (DecoderState, StepOutcome[A])] = {
+    val step =
+      ZPure
+        .modify[DecoderState, DecoderState, Either[CodecError, StepOutcome[A]]] { st =>
+          decodeChunk(decoder, once, failOnError)(st, chunk) match {
+            case Left(err)              => (Left(err), st)
+            case Right((next, outcome)) => (Right(outcome), next)
+          }
+        }
+        .flatMap {
+          case Left(err)      => ZPure.fail(err)
+          case Right(outcome) => ZPure.succeed(outcome)
+        }
+
+    val (_, either) = step.runAll(state)
+    either match {
+      case Left(err)              => Left(err)
+      case Right((next, outcome)) => Right(next -> outcome)
+    }
+  }
+
+  private def decodeChunk[A](
+    decoder: Decoder[A],
+    once: Boolean,
+    failOnError: Boolean,
+  )(
+    state: DecoderState,
+    input: Chunk[BitVector],
+  ): Either[CodecError, (DecoderState, StepOutcome[A])] = {
+    var buffer   = state.buffer
+    var awaiting = state.awaiting
+    val builder  = ChunkBuilder.make[A]()
+    var stop     = false
+    var idx      = 0
+
+    while (idx < input.length && !stop) {
+      val bits = input(idx)
+      if (!bits.isEmpty) {
+        buffer = buffer ++ bits
+        awaiting = None
+        var continue = true
+
+        while (continue && !stop) {
+          decoder.decode(buffer) match {
+            case Attempt.Successful(DecodeResult(value, remainder)) =>
+              val consumed = remainder.size != buffer.size
+
+              if (!consumed && !once) {
+                return Left(CodecError(Err("decoder did not consume any input")))
+              }
+
+              builder += value
+              buffer = remainder
+              awaiting = None
+
+              if (once) {
+                stop = true
+                continue = false
+              } else {
+                continue = consumed && buffer.nonEmpty
+              }
+            case Attempt.Failure(err)                               =>
+              findInsufficient(err) match {
+                case Some(insufficient) =>
+                  awaiting = Some(insufficient)
+                  continue = false
+                case None               =>
+                  if (failOnError) return Left(CodecError(err))
+                  else {
+                    buffer = BitVector.empty
+                    awaiting = None
+                    stop = true
+                    continue = false
+                  }
+              }
+          }
+        }
+      }
+
+      idx += 1
+    }
+
+    val nextState = DecoderState(buffer, awaiting)
+    Right(nextState -> StepOutcome(builder.result(), stop))
+  }
+
+  private def findInsufficient(err: Err): Option[Err.InsufficientBits] =
+    err match {
+      case e: Err.InsufficientBits => Some(e)
+      case Err.Composite(errs, _)  =>
+        errs
+          .collectFirst { case nested: Err.InsufficientBits => nested }
+          .orElse(errs.view.flatMap(findInsufficient).headOption)
+      case _                       => None
+    }
+}

--- a/modules/core/src/test/scala/graviton/interop/scodec/ZStreamDecoderSpec.scala
+++ b/modules/core/src/test/scala/graviton/interop/scodec/ZStreamDecoderSpec.scala
@@ -1,0 +1,146 @@
+package graviton.interop.scodec
+
+import zio._
+import zio.stream._
+import zio.test._
+import zio.ChunkBuilder
+import zio.Exit
+
+import java.nio.charset.{Charset, StandardCharsets}
+
+import _root_.scodec.bits.BitVector
+import _root_.scodec.codecs
+import _root_.scodec.{Attempt, DecodeResult, Decoder, Err}
+
+object ZStreamDecoderSpec extends ZIOSpecDefault {
+
+  private val int32Codec   = codecs.int32
+  private val int32Decoder = int32Codec.asDecoder
+
+  private val int8Codec = codecs.int8
+
+  private val positiveByteDecoder: Decoder[Int] =
+    int8Codec.asDecoder.emap { value =>
+      if (value >= 0) Attempt.successful(value)
+      else Attempt.failure(Err("negative value"))
+    }
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("ZStreamDecoder")(
+      test("once decodes a single value across chunk boundaries") {
+        val encoded = int32Codec.encode(0xdeadbeef).require
+        val chunks  = split(encoded, 5, 11, 7, 9)
+
+        val effect =
+          ZStream
+            .fromIterable(chunks)
+            .via(ZStreamDecoder.once(int32Decoder))
+            .runCollect
+
+        assertZIO(effect)(Assertion.equalTo(Chunk(0xdeadbeef)))
+      },
+      test("many decodes multiple values with irregular chunk sizes") {
+        val encoded = Chunk(1, 2, 3).map(int32Codec.encode(_).require).reduce(_ ++ _)
+        val chunks  = split(encoded, 4, 3, 16, 5, 7, 9, 6, 6)
+
+        val effect =
+          ZStream
+            .fromIterable(chunks)
+            .via(ZStreamDecoder.many(int32Decoder))
+            .runCollect
+
+        assertZIO(effect)(Assertion.equalTo(Chunk(1, 2, 3)))
+      },
+      test("once completes without emission when input ends prematurely") {
+        val partial = BitVector.fromInt(0x123456, 24)
+
+        val effect =
+          ZStream
+            .fromIterable(Chunk(partial.take(10), partial.drop(10)))
+            .via(ZStreamDecoder.once(int32Decoder))
+            .runCollect
+
+        assertZIO(effect)(Assertion.isEmpty)
+      },
+      test("many fails fast on unrecoverable errors") {
+        val encoded = Chunk(5, -1, 7).map(int8Codec.encode(_).require)
+        val stream  = ZStream.fromIterable(split(encoded.reduce(_ ++ _), 4, 4, 4, 4, 4, 4))
+
+        for {
+          exit <- stream.via(ZStreamDecoder.many(positiveByteDecoder)).runCollect.exit
+        } yield exit match {
+          case Exit.Failure(cause) =>
+            val codecFailure = cause.failureOption.collect { case err: CodecError => err }
+            assertTrue(codecFailure.isDefined)
+          case Exit.Success(_)     => assertTrue(false)
+        }
+      },
+      test("tryMany stops gracefully after an unrecoverable error") {
+        val encoded = Chunk(5, -1, 7).map(int8Codec.encode(_).require)
+        val chunks  = split(encoded.reduce(_ ++ _), 5, 7, 6, 6)
+
+        val effect =
+          ZStream
+            .fromIterable(chunks)
+            .via(ZStreamDecoder.tryMany(positiveByteDecoder))
+            .runCollect
+
+        assertZIO(effect)(Assertion.equalTo(Chunk(5)))
+      },
+      test("once can emit a value without consuming input for peek decoders") {
+        val ascii  = headerBits(0x3031)
+        val ebcdic = headerBits(0xf0f1)
+
+        val effect =
+          for {
+            asciiDetected  <-
+              ZStream
+                .fromIterable(Chunk(ascii))
+                .via(ZStreamDecoder.once(charsetPeekDecoder))
+                .runCollect
+            ebcdicDetected <-
+              ZStream
+                .fromIterable(Chunk(ebcdic))
+                .via(ZStreamDecoder.once(charsetPeekDecoder))
+                .runCollect
+          } yield asciiDetected -> ebcdicDetected
+
+        val expected = (Chunk(StandardCharsets.US_ASCII), Chunk(Ibm037))
+
+        assertZIO(effect)(Assertion.equalTo(expected))
+      },
+    )
+
+  private def split(bits: BitVector, parts: Int*): Chunk[BitVector] = {
+    val builder = ChunkBuilder.make[BitVector]()
+    var start   = bits
+    parts.foreach { size =>
+      val (chunk, remainder) = start.splitAt(size.toLong)
+      if (chunk.nonEmpty) builder += chunk
+      start = remainder
+    }
+    if (start.nonEmpty) builder += start
+    builder.result()
+  }
+
+  private val Ibm037: Charset = Charset.forName("IBM037")
+
+  private val charsetPeekDecoder: Decoder[Charset] =
+    new Decoder[Charset] {
+      private val EbcdicEncoding = 0xf0f1.toShort
+      private val AsciiEncoding  = 0x3031.toShort
+
+      override def decode(bits: BitVector): Attempt[DecodeResult[Charset]] =
+        (codecs.ignore(32) ~> codecs.short16).decode(bits).flatMap {
+          case DecodeResult(`EbcdicEncoding`, _) =>
+            Attempt.successful(DecodeResult(Ibm037, bits))
+          case DecodeResult(`AsciiEncoding`, _)  =>
+            Attempt.successful(DecodeResult(StandardCharsets.US_ASCII, bits))
+          case DecodeResult(other, _)            =>
+            Attempt.failure(Err(s"Unexpected marker: 0x${(other & 0xffff).toHexString.toUpperCase}"))
+        }
+    }
+
+  private def headerBits(marker: Int): BitVector =
+    BitVector.fromInt(0x50, 32) ++ BitVector.fromInt(marker, 16)
+}


### PR DESCRIPTION
## Summary
- allow the streaming decoder to accept non-consuming decoders in once/tryOnce mode while still preventing infinite loops in many-mode
- add a regression test that exercises an encoding-detection peek decoder inspired by the FS2/scodec article

## Testing
- TESTCONTAINERS=0 ./sbt scalafmtAll test

------
https://chatgpt.com/codex/tasks/task_b_68df1f2aef64832e9adafb45fb3ef9a9