### PR TITLE
Add ZPure-based streaming codec

### DIFF
--- a/modules/core/src/main/scala/graviton/codec/StreamCodec.scala
+++ b/modules/core/src/main/scala/graviton/codec/StreamCodec.scala
@@ -1,0 +1,266 @@
+package graviton.codec
+
+import zio.*
+import zio.stream.*
+import zio.prelude.fx.ZPure
+import zio.ChunkBuilder
+
+/**
+ * A state machine for streaming codecs built on top of [[ZPure]].
+ *
+ * The implementation keeps track of leftover bytes, recoverable decoding
+ * failures, stream completion and optional diagnostic logs entirely in the
+ * pure state.  Each decoding step emits [[Take]] values so that downstream
+ * consumers can recover from insufficient input by continuing to push more
+ * chunks into the channel.
+ */
+final class StreamCodec[+A](
+  val initial: StreamCodecState,
+  val onChunk: Chunk[Byte] => StreamCodec.CodecPure[Chunk[Take[StreamCodecError, A]]],
+  val onEnd: StreamCodec.CodecPure[Chunk[Take[StreamCodecError, A]]],
+):
+
+  /**
+   * Convert this codec into a [[ZChannel]].
+   */
+  def toChannel: ZChannel[Any, Nothing, Chunk[Byte], Any, Nothing, Take[StreamCodecError, A], Any] =
+    def loop(state: StreamCodecState): ZChannel[Any, Nothing, Chunk[Byte], Any, Nothing, Take[StreamCodecError, A], Any] =
+      state.status match
+        case StreamStatus.Completed     =>
+          ZChannel.write(Take.end) *> ZChannel.unit
+        case StreamStatus.Failed(error) =>
+          ZChannel.write(Take.fail(error)) *> ZChannel.unit
+        case StreamStatus.Running       =>
+          ZChannel.readWith(
+            chunk =>
+              val (logs, result)     = onChunk(chunk).runAll(state)
+              val (nextState, takes) = result match
+                case Right((st, out)) => (st.recordLogs(logs), out)
+                case Left(_)          => (state, Chunk.empty)
+              emitAll(takes) *> loop(nextState)
+            ,
+            cause => ZChannel.refailCause(cause),
+            _ =>
+              val (logs, result)     = onEnd.runAll(state)
+              val (nextState, takes) = result match
+                case Right((st, out)) => (st.recordLogs(logs), out)
+                case Left(_)          => (state, Chunk.empty)
+              emitAll(takes),
+          )
+    loop(initial)
+
+  private def emitAll(takes: Chunk[Take[StreamCodecError, A]]): ZChannel[Any, Nothing, Any, Any, Nothing, Take[StreamCodecError, A], Any] =
+    def emitAt(idx: Int): ZChannel[Any, Nothing, Any, Any, Nothing, Take[StreamCodecError, A], Any] =
+      if idx >= takes.length then ZChannel.unit
+      else
+        val current = takes(idx)
+        if current.isDone || current.isFailure then ZChannel.write(current)
+        else ZChannel.write(current) *> emitAt(idx + 1)
+    emitAt(0)
+
+object StreamCodec:
+  type CodecPure[+A] = ZPure[CodecLogEntry, StreamCodecState, StreamCodecState, Any, Nothing, A]
+
+  /**
+   * Construct a codec that decodes fixed-size records using the supplied
+   * decoding function.  Failures in the decoder are treated as fatal, while
+   * insufficient input is recorded as a recoverable condition so that the next
+   * chunk can attempt the decode again.
+   */
+  def fixedSize[A](
+    size: Int
+  )(decode: Chunk[Byte] => Either[String, A]): StreamCodec[A] =
+    require(size > 0, "record size must be strictly positive")
+    val initialState = StreamCodecState.empty
+    new StreamCodec(
+      initialState,
+      chunk =>
+        for
+          _       <- ZPure.log(CodecLogEntry.received(chunk.length))
+          outputs <- ZPure.modify { (state: StreamCodecState) =>
+                       val appended             = state.appendInput(chunk)
+                       val (updated, emissions) = decodeAvailable(appended, size, decode)
+                       (emissions, updated)
+                     }
+        yield outputs,
+      for outputs <- ZPure.modify { (state: StreamCodecState) =>
+                       val (updated, emissions) = finishDecoding(state, size)
+                       (emissions, updated)
+                     }
+      yield outputs,
+    )
+
+  private[codec] def decodeAvailable[A](
+    state: StreamCodecState,
+    size: Int,
+    decode: Chunk[Byte] => Either[String, A],
+  ): (StreamCodecState, Chunk[Take[StreamCodecError, A]]) =
+    val builder          = ChunkBuilder.make[Take[StreamCodecError, A]]()
+    var working          = state.prepareForDecode
+    var continueDecoding = true
+
+    while continueDecoding && working.buffer.length >= size do
+      val (record, remainder) = working.buffer.splitAt(size)
+      decode(record) match
+        case Left(message) =>
+          val error = StreamCodecError.DecoderFailure(message)
+          working = working.withBuffer(remainder).recordFatal(error)
+          builder += Take.fail(error)
+          continueDecoding = false
+        case Right(value)  =>
+          working = working
+            .withBuffer(remainder)
+            .recordEmission(value)
+          builder += Take.chunk(Chunk.single(value))
+    if continueDecoding then
+      if working.buffer.nonEmpty then working = working.markInsufficientInput(size)
+      else working = working.clearRecoverable
+    (working, builder.result())
+
+  private[codec] def finishDecoding[A](
+    state: StreamCodecState,
+    size: Int,
+  ): (StreamCodecState, Chunk[Take[StreamCodecError, A]]) =
+    val builder = ChunkBuilder.make[Take[StreamCodecError, A]]()
+    val next    = state.status match
+      case StreamStatus.Completed => state
+      case StreamStatus.Failed(_) => state
+      case StreamStatus.Running   =>
+        if state.buffer.isEmpty then
+          builder += Take.end
+          state.complete
+        else
+          val error = StreamCodecError.UnexpectedEnd(state.buffer.length, size)
+          builder += Take.fail(error)
+          builder += Take.end
+          state.recordFatal(error).clearBuffer
+    (next, builder.result())
+
+final case class StreamCodecState(
+  buffer: Chunk[Byte],
+  status: StreamStatus,
+  flags: Set[CodecFlag],
+  logs: Chunk[CodecLogEntry],
+  stats: CodecStats,
+  lastFailure: Option[CodecFailure],
+):
+
+  def appendInput(chunk: Chunk[Byte]): StreamCodecState =
+    copy(
+      buffer = buffer ++ chunk,
+      stats = stats.recordBuffered(chunk.length),
+      flags = flags - CodecFlag.NeedsMoreInput,
+      lastFailure = lastFailure.filterNot(_.recoverable),
+      logs = logs :+ CodecLogEntry.received(chunk.length),
+    )
+
+  def clearBuffer: StreamCodecState = copy(buffer = Chunk.empty)
+
+  def clearRecoverable: StreamCodecState =
+    copy(
+      flags = flags - CodecFlag.NeedsMoreInput,
+      lastFailure = lastFailure.filterNot(_.recoverable),
+    )
+
+  def complete: StreamCodecState =
+    copy(
+      status = StreamStatus.Completed,
+      flags = (flags - CodecFlag.NeedsMoreInput) + CodecFlag.Completed,
+      logs = logs :+ CodecLogEntry.completed,
+    )
+
+  def markInsufficientInput(required: Int): StreamCodecState =
+    val error = StreamCodecError.InsufficientBytes(required, buffer.length)
+    copy(
+      flags = flags + CodecFlag.NeedsMoreInput,
+      stats = stats.recordRecoverableFailure,
+      lastFailure = Some(CodecFailure(error, recoverable = true)),
+      logs = logs :+ CodecLogEntry.insufficient(buffer.length, required),
+    )
+
+  def prepareForDecode: StreamCodecState =
+    copy(
+      flags = flags - CodecFlag.NeedsMoreInput,
+      lastFailure = lastFailure.filterNot(_.recoverable),
+    )
+
+  def recordEmission[A](value: A): StreamCodecState =
+    copy(
+      stats = stats.recordEmission,
+      logs = logs :+ CodecLogEntry.decoded(value.toString, buffer.length),
+    )
+
+  def recordFatal(error: StreamCodecError): StreamCodecState =
+    copy(
+      status = StreamStatus.Failed(error),
+      flags = flags + CodecFlag.Failed,
+      stats = stats.recordFatalFailure,
+      lastFailure = Some(CodecFailure(error, recoverable = false)),
+      logs = logs :+ CodecLogEntry.fatal(error.getMessage),
+    )
+
+  def recordLogs(entries: Chunk[CodecLogEntry]): StreamCodecState =
+    if entries.isEmpty then this else copy(logs = logs ++ entries)
+
+  def withBuffer(newBuffer: Chunk[Byte]): StreamCodecState = copy(buffer = newBuffer)
+
+object StreamCodecState:
+  val empty: StreamCodecState = StreamCodecState(
+    buffer = Chunk.empty,
+    status = StreamStatus.Running,
+    flags = Set.empty,
+    logs = Chunk.empty,
+    stats = CodecStats.empty,
+    lastFailure = None,
+  )
+
+final case class CodecStats(
+  bufferedBytes: Long,
+  emittedValues: Long,
+  recoverableFailures: Long,
+  fatalFailures: Long,
+):
+  def recordBuffered(n: Int): CodecStats   = copy(bufferedBytes = bufferedBytes + n.toLong)
+  def recordEmission: CodecStats           = copy(emittedValues = emittedValues + 1)
+  def recordRecoverableFailure: CodecStats = copy(recoverableFailures = recoverableFailures + 1)
+  def recordFatalFailure: CodecStats       = copy(fatalFailures = fatalFailures + 1)
+
+object CodecStats:
+  val empty: CodecStats = CodecStats(0L, 0L, 0L, 0L)
+
+final case class CodecFailure(error: StreamCodecError, recoverable: Boolean)
+
+enum CodecFlag:
+  case NeedsMoreInput, Completed, Failed
+
+enum StreamStatus:
+  case Running
+  case Completed
+  case Failed(error: StreamCodecError)
+
+enum CodecLogEntry:
+  case Received(bytes: Int)
+  case Insufficient(available: Int, required: Int)
+  case Decoded(value: String, remaining: Int)
+  case Fatal(message: String)
+  case Completed
+
+object CodecLogEntry:
+  def received(bytes: Int): CodecLogEntry                   = CodecLogEntry.Received(bytes)
+  def insufficient(available: Int, required: Int)           = CodecLogEntry.Insufficient(available, required)
+  def decoded(value: String, remaining: Int): CodecLogEntry = CodecLogEntry.Decoded(value, remaining)
+  def fatal(message: String): CodecLogEntry                 = CodecLogEntry.Fatal(message)
+  val completed: CodecLogEntry                              = CodecLogEntry.Completed
+
+sealed trait StreamCodecError extends RuntimeException:
+  override def getMessage: String = this match
+    case StreamCodecError.InsufficientBytes(required, available) =>
+      s"insufficient bytes: required=$required available=$available"
+    case StreamCodecError.UnexpectedEnd(remaining, expectedSize) =>
+      s"unexpected end of stream: remaining=$remaining expectedSize=$expectedSize"
+    case StreamCodecError.DecoderFailure(message)                => s"decoder failure: $message"
+
+object StreamCodecError:
+  final case class InsufficientBytes(required: Int, available: Int) extends StreamCodecError
+  final case class UnexpectedEnd(remaining: Int, expectedSize: Int) extends StreamCodecError
+  final case class DecoderFailure(message: String)                  extends StreamCodecError

--- a/modules/core/src/test/scala/graviton/codec/StreamCodecSpec.scala
+++ b/modules/core/src/test/scala/graviton/codec/StreamCodecSpec.scala
@@ -1,0 +1,73 @@
+package graviton.codec
+
+import zio.*
+import zio.test.*
+
+object StreamCodecSpec extends ZIOSpecDefault:
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("StreamCodec")(
+      test("buffers leftovers until a record completes") {
+        val codec          = StreamCodec.fixedSize[Int](3)(decodeInt24)
+        val first          = chunk(0x00, 0x01)
+        val (logs1, res1)  = codec.onChunk(first).runAll(codec.initial)
+        val (state1, out1) = res1.toOption.get
+
+        assertTrue(out1.isEmpty) &&
+        assertTrue(state1.buffer.length == 2) &&
+        assertTrue(state1.flags.contains(CodecFlag.NeedsMoreInput)) &&
+        assertTrue(logs1.nonEmpty)
+      },
+      test("decodes values once enough bytes arrive") {
+        val codec          = StreamCodec.fixedSize[Int](3)(decodeInt24)
+        val first          = chunk(0x00, 0x01)
+        val (_, res1)      = codec.onChunk(first).runAll(codec.initial)
+        val (state1, _)    = res1.toOption.get
+        val second         = chunk(0x02, 0x03, 0x04)
+        val (_, res2)      = codec.onChunk(second).runAll(state1)
+        val (state2, out2) = res2.toOption.get
+
+        val emitted = out2.flatMap(_.fold(Chunk.empty[Int], _ => Chunk.empty, identity))
+        assertTrue(emitted == Chunk(0x000102)) &&
+        assertTrue(state2.buffer.length == 2) &&
+        assertTrue(state2.flags.contains(CodecFlag.NeedsMoreInput))
+      },
+      test("reports fatal decoder failures") {
+        val codec            = StreamCodec.fixedSize[Int](3) { bytes =>
+          decodeInt24(bytes).flatMap { value =>
+            if value == 0x000102 then Left("boom") else Right(value)
+          }
+        }
+        val chunkData        = chunk(0x00, 0x01, 0x02, 0x03, 0x04)
+        val (_, res)         = codec.onChunk(chunkData).runAll(codec.initial)
+        val (state, outputs) = res.toOption.get
+
+        val failure = outputs.find(_.isFailure)
+        assertTrue(failure.isDefined) &&
+        assertTrue(state.status == StreamStatus.Failed(StreamCodecError.DecoderFailure("boom")))
+      },
+      test("fails when stream ends with leftover bytes") {
+        val codec             = StreamCodec.fixedSize[Int](3)(decodeInt24)
+        val chunkData         = chunk(0x00, 0x01)
+        val (_, midRes)       = codec.onChunk(chunkData).runAll(codec.initial)
+        val (midState, _)     = midRes.toOption.get
+        val (_, finalRes)     = codec.onEnd.runAll(midState)
+        val (finalState, out) = finalRes.toOption.get
+
+        val fail = out.find(_.isFailure)
+        val end  = out.find(_.isDone)
+        assertTrue(fail.isDefined) &&
+        assertTrue(end.isDefined) &&
+        assertTrue(finalState.status == StreamStatus.Failed(StreamCodecError.UnexpectedEnd(2, 3)))
+      },
+    )
+
+  private def decodeInt24(bytes: Chunk[Byte]): Either[String, Int] =
+    if bytes.length != 3 then Left(s"expected 3 bytes, received ${bytes.length}")
+    else
+      val b0 = bytes(0) & 0xff
+      val b1 = bytes(1) & 0xff
+      val b2 = bytes(2) & 0xff
+      Right((b0 << 16) | (b1 << 8) | b2)
+
+  private def chunk(bytes: Int*): Chunk[Byte] =
+    Chunk.fromArray(bytes.map(_.toByte).toArray)


### PR DESCRIPTION
## Summary
- add a ZPure-backed `StreamCodec` state machine with channel conversion helpers, status tracking, and logging
- provide codec support types for flags, stats, errors, and logs alongside a fixed-size codec constructor
- cover buffering, emission, fatal failure, and end-of-stream scenarios with a new ZIO Test suite

## Testing
- `TESTCONTAINERS=0 ./sbt scalafmtAll test`

------
https://chatgpt.com/codex/tasks/task_b_68df1ef7fb4c832e9d16fc66ace92472